### PR TITLE
Add functions to distribute the workload among MPI processes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+# Flake8 complains about the formatting of ":" done by black
+# Since black is PEP8-compliant, we silence flake8.
+ignore = W503, E203

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ instance/
 # Scrapy stuff:
 .scrapy
 
+# Sphinx documentation
+docs/build/
+
 # PyBuilder
 target/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
 script:
   - sh ./bin/run_tests.sh
   - |
-    if [[ "MPI" != "none"   ]]; then
+    if [[ "$MPI" != "none"   ]]; then
         for proc in 1 2; do
             echo "Running MPI test ($MPI) with $proc processes"
             mpiexec -n $proc poetry run python3 ./test/mpi/test_mpi.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,42 +4,15 @@ python:
   - 3.6
   - 3.7
 
+os:
+  - linux
+  - osx
+  
 env:
   matrix:
-    - MPI=none
-    - MPI=mpich
-    - MPI=openmpi
-
-matrix:
-  include:
-    - os: "osx"
-      osx_image: "xcode10"
-      env: "MPI=mpich EXTRAS=--extras=mpi"
-      language: "generic"
-      python: "3.6"
-    - os: "osx"
-      osx_image: "xcode10"
-      env: "MPI=none EXTRAS="
-      language: "generic"
-      python: "3.6"
-      
-    - os: "linux"
-      env: "MPI=openmpi EXTRAS=--extras=mpi"
-      language: "generic"
-      python: "3.6"
-    - os: "linux"
-      env: "MPI=none EXTRAS="
-      language: "generic"
-      python: "3.6"
-
-    - os: "linux"
-      env: "MPI=mpich EXTRAS=--extras=mpi"
-      language: "generic"
-      python: "3.6"
-    - os: "linux"
-      env: "MPI=none EXTRAS="
-      language: "generic"
-      python: "3.6"
+    - MPI=none     EXTRAS=
+    - MPI=mpich    EXTRAS=--extras=mpi
+    - MPI=openmpi  EXTRAS=--extras=mpi
   
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,55 @@ python:
   - "3.6"
   - "3.7"
 
+matrix:
+  include:
+    - os: "osx"
+      osx_image: "xcode10"
+      env: "MPI=mpich EXTRAS=--extras=mpi"
+      language: "generic"
+      python: 3
+    - os: "osx"
+      osx_image: "xcode10"
+      env: "MPI=none EXTRAS="
+      language: "generic"
+      python: 3
+      
+    - os: "linux"
+      env: "MPI=openmpi EXTRAS=--extras=mpi"
+      language: "generic"
+      python: 3
+    - os: "linux"
+      env: "MPI=none EXTRAS="
+      language: "generic"
+      python: 3
+
+    - os: "linux"
+      env: "MPI=mpich EXTRAS=--extras=mpi"
+      language: "generic"
+      python: 3
+    - os: "linux"
+      env: "MPI=none EXTRAS="
+      language: "generic"
+      python: 3
+  
+cache:
+  apt: true
+
+addons:
+  apt:
+    update: true
+  homebrew:
+    update: true
+    
 before_install:
+  - ./bin/install-mpi.sh $MPI
+  - if [[ "$MPI" == "mpich"   ]]; then mpichversion; fi
+  - if [[ "$MPI" == "openmpi" ]]; then ompi_info;    fi
   - pip install poetry
 
 install:
-  - poetry install --extras=docs
+  - poetry install --extras=docs $EXTRAS
 
 script:
   - sh ./bin/run_tests.sh
+  - if [[ "MPI" != "none"   ]]; then for proc in 1 2; do mpiexec -n $proc poetry run python ./test/mpi/test_mpi.py; done; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,35 @@
 language: python
 
-python:
-  - "3.6"
-  - "3.7"
-
 matrix:
   include:
     - os: "osx"
       osx_image: "xcode10"
       env: "MPI=mpich EXTRAS=--extras=mpi"
       language: "generic"
-      python: 3
+      python: "3.6"
     - os: "osx"
       osx_image: "xcode10"
       env: "MPI=none EXTRAS="
       language: "generic"
-      python: 3
+      python: "3.6"
       
     - os: "linux"
       env: "MPI=openmpi EXTRAS=--extras=mpi"
       language: "generic"
-      python: 3
+      python: "3.6"
     - os: "linux"
       env: "MPI=none EXTRAS="
       language: "generic"
-      python: 3
+      python: "3.6"
 
     - os: "linux"
       env: "MPI=mpich EXTRAS=--extras=mpi"
       language: "generic"
-      python: 3
+      python: "3.6"
     - os: "linux"
       env: "MPI=none EXTRAS="
       language: "generic"
-      python: 3
+      python: "3.6"
   
 cache:
   apt: true
@@ -55,4 +51,10 @@ install:
 
 script:
   - sh ./bin/run_tests.sh
-  - if [[ "MPI" != "none"   ]]; then for proc in 1 2; do mpiexec -n $proc poetry run python ./test/mpi/test_mpi.py; done; fi
+  - |
+    if [[ "MPI" != "none"   ]]; then
+        for proc in 1 2; do
+            echo "Running MPI test ($MPI) with $proc processes"
+            mpiexec -n $proc poetry run python3 ./test/mpi/test_mpi.py
+        done
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,47 @@ python:
 
 os:
   - linux
-  - osx
   
 env:
   matrix:
     - MPI=none     EXTRAS=
     - MPI=mpich    EXTRAS=--extras=mpi
     - MPI=openmpi  EXTRAS=--extras=mpi
-  
+
+
+matrix:
+  include:
+    - name: "Python 3.6 on MacOSX (no MPI)"
+      os: osx
+      osx_image: xcode9.4
+      language: shell
+      env: MPI=none EXTRAS=
+    - name: "Python 3.7 on MacOSX (no MPI)"
+      os: osx
+      osx_image: xcode10.2
+      language: shell
+      env: MPI=none EXTRAS=
+    - name: "Python 3.6 on MacOSX (mpich)"
+      os: osx
+      osx_image: xcode9.4
+      language: shell
+      env: MPI=mpich EXTRAS=--extras=mpi
+    - name: "Python 3.6 on MacOSX (openmpi)"
+      os: osx
+      osx_image: xcode9.4
+      language: shell
+      env: MPI=openmpi EXTRAS=--extras=mpi
+    - name: "Python 3.7 on MacOSX (mpich)"
+      os: osx
+      osx_image: xcode10.2
+      language: shell
+      env: MPI=mpich EXTRAS=--extras=mpi
+    - name: "Python 3.7 on MacOSX (openmpi)"
+      os: osx
+      osx_image: xcode10.2
+      language: shell
+      env: MPI=openmpi EXTRAS=--extras=mpi
+    
 cache:
   apt: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 language: python
 
+python:
+  - 3.6
+  - 3.7
+
+env:
+  matrix:
+    - MPI=none
+    - MPI=mpich
+    - MPI=openmpi
+
 matrix:
   include:
     - os: "osx"
@@ -44,7 +54,7 @@ before_install:
   - ./bin/install-mpi.sh $MPI
   - if [[ "$MPI" == "mpich"   ]]; then mpichversion; fi
   - if [[ "$MPI" == "openmpi" ]]; then ompi_info;    fi
-  - pip install poetry
+  - pip3 install poetry
 
 install:
   - poetry install --extras=docs $EXTRAS

--- a/bin/install-mpi.sh
+++ b/bin/install-mpi.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# This script is based on the one in mpi4py's distribution
+# It is currently used by the Travis CI script
+
+set -e
+case `uname` in
+Linux)
+  case $1 in
+    none)
+      ;;      
+    mpich) set -x;
+      sudo apt-get install -y -q mpich libmpich-dev
+      ;;
+    openmpi) set -x;
+      sudo apt-get install -y -q openmpi-bin libopenmpi-dev
+      ;;
+    *)
+      echo "Unknown MPI implementation:" $1
+      exit 1
+      ;;
+  esac
+  ;;
+Darwin)
+  case $1 in
+    none)
+      ;;      
+    mpich) set -x;
+      brew install mpich
+      ;;
+    openmpi) set -x;
+      brew install openmpi
+      ;;
+    *)
+      echo "Unknown MPI implementation:" $1
+      exit 1
+      ;;
+  esac
+  ;;
+esac

--- a/bin/install-mpi.sh
+++ b/bin/install-mpi.sh
@@ -8,11 +8,14 @@ case `uname` in
 Linux)
   case $1 in
     none)
+      echo "Skipping the installation of a MPI library"
       ;;      
     mpich) set -x;
+      echo "Installing mpich"
       sudo apt-get install -y -q mpich libmpich-dev
       ;;
-    openmpi) set -x;
+    openmpi) set -x; 
+      echo "Installing openmpi"
       sudo apt-get install -y -q openmpi-bin libopenmpi-dev
       ;;
     *)
@@ -24,11 +27,14 @@ Linux)
 Darwin)
   case $1 in
     none)
+      echo "Skipping the installation of a MPI library"
       ;;      
     mpich) set -x;
+      echo "Installing mpich"
       brew install mpich
       ;;
     openmpi) set -x;
+      echo "Installing openmpi"
       brew install openmpi
       ;;
     *)

--- a/bin/run_tests.bat
+++ b/bin/run_tests.bat
@@ -9,4 +9,4 @@ rem Check for common errors
 poetry run flake8 --max-line-length %MAX_LINE_LENGTH%
 
 rem Run the test suite
-poetry run python3 -m pytest
+poetry run python3 -m pytest --doctest-modules -vv

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -9,4 +9,4 @@ poetry run black --check --line-length=${MAX_LINE_LENGTH} -q .
 poetry run flake8 --max-line-length=${MAX_LINE_LENGTH}
 
 # Run the test suite
-poetry run python3 -m pytest --doctest-modules -vv
+poetry run python3 -m pytest --doctest-modules --ignore=test/mpi -vv

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -9,4 +9,4 @@ poetry run black --check --line-length=${MAX_LINE_LENGTH} -q .
 poetry run flake8 --max-line-length=${MAX_LINE_LENGTH}
 
 # Run the test suite
-poetry run python3 -m pytest -vv
+poetry run python3 -m pytest --doctest-modules -vv

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@ Welcome to litebird_sim's documentation!
    tutorial
    simulations
    observations
+   mpi
 
 Indices and tables
 ==================

--- a/docs/source/mpi.rst
+++ b/docs/source/mpi.rst
@@ -7,36 +7,43 @@ The LiteBIRD Simulation Framework lists mpi4py as an *optional*
 dependency. This means that simulation codes should be able to cope
 with the lack of MPI.
 
-The framework provides a global variable, ``MPI_COMM_WORLD``, which
-behaves like ``mpi4py.MPI.COMM_WORLD`` but is defined even if MPI is
-not present. It has the following features:
+The framework can be forced to use MPI or not using the variable
+``LITEBIRD_SIM_MPI``:
 
-- The member variables ``rank`` and ``size`` are always defined, even
-  in absence of ``mpi4py`` (in this case they are set to 0 and 1,
-  respectively);
-- A member variable ``have_mpi`` is set to ``True`` if ``mpi4py`` was
-  imported;
-- Importing ``mpi4py`` can be controlled through the environment
-  variable ``LITEBIRD_SIM_MPI``.
+- Set the variable to 1 or an empty value to *force* importing `mpi4py`;
+- Set the variable to 0 to avoid importing `mpi4py`;
+- If the variable is not set, the code will try to import `mpi4py`,
+  but in case of error it will not complain and will silently shift to
+  serial execution.
 
-Thus, the following code will always work, regardless of the fact that
-``mpi4py`` was found and imported or not::
+The framework provides a global variable, :data:`.MPI_COMM_WORLD`,
+which is the same as ``mpi4py.MPI.COMM_WORLD`` if MPI is being used.
+Otherwise, it contains only the following members:
+
+- `rank` (set to ``0``);
+- `size` (set to ``1``).
+
+Thus, the following code works regardless whether MPI is present or
+not::
 
   import litebird_sim as lbs
 
   if lbs.MPI_COMM_WORLD.rank == 0:
       print("Hello, world!")
 
-However, you can call MPI functions only if
-``MPI.COMM_WORLD.have_mpi`` is ``True``:
+However, you can use :data:`.MPI_COMM_WORLD` to call MPI functions
+only if MPI was actually enabled. You can check this using the Boolean
+variable :data:`.MPI_ENABLED`::
 
   import litebird_sim as lbs
 
   comm = lbs.MPI_COMM_WORLD
-  if lbs.MPI_COMM_WORLD.have_mpi:
-      # The MPI call to "barrier" is broadcasted to mpi4py
+  if lbs.MPI_ENABLED:
       comm.barrier()
 
+
+To ensure that your code uses MPI in the proper way, you should always
+use ``.MPI_COMM_WORLD`` instead of importing ``mpi4py`` directly.
 
 
 Enabling/disabling MPI

--- a/docs/source/mpi.rst
+++ b/docs/source/mpi.rst
@@ -7,30 +7,56 @@ The LiteBIRD Simulation Framework lists mpi4py as an *optional*
 dependency. This means that simulation codes should be able to cope
 with the lack of MPI.
 
-The following table lists the variable that can be used to detect if
-MPI is present or not:
+The framework provides a global variable, ``MPI_COMM_WORLD``, which
+behaves like ``mpi4py.MPI.COMM_WORLD`` but is defined even if MPI is
+not present. It has the following features:
+
+- The member variables ``rank`` and ``size`` are always defined, even
+  in absence of ``mpi4py`` (in this case they are set to 0 and 1,
+  respectively);
+- A member variable ``have_mpi`` is set to ``True`` if ``mpi4py`` was
+  imported;
+- Importing ``mpi4py`` can be controlled through the environment
+  variable ``LITEBIRD_SIM_MPI``.
+
+Thus, the following code will always work, regardless of the fact that
+``mpi4py`` was found and imported or not::
+
+  import litebird_sim as lbs
+
+  if lbs.MPI_COMM_WORLD.rank == 0:
+      print("Hello, world!")
+
+However, you can call MPI functions only if
+``MPI.COMM_WORLD.have_mpi`` is ``True``:
+
+  import litebird_sim as lbs
+
+  comm = lbs.MPI_COMM_WORLD
+  if lbs.MPI_COMM_WORLD.have_mpi:
+      # The MPI call to "barrier" is broadcasted to mpi4py
+      comm.barrier()
 
 
-+----------------------------+-------+---------------------------------------+
-| Variable                   | Value | Meaning                               |
-+----------------------------+-------+---------------------------------------+
-| :data:`.HAVE_MPI4PY`       | Bool  | ``True`` if mpi4py was imported       |
-+----------------------------+-------+---------------------------------------+
-| :data:`.MPI_RANK`          | Int   | Rank of current MPI process, in       |
-|                            |       | the range ``0 … MPI_SIZE - 1``        |
-|                            |       | (0 if MPI is not available)           |
-+----------------------------+-------+---------------------------------------+
-| :data:`.MPI_SIZE`          | Int   | Number of available MPI processes     |
-|                            |       | (1 if MPI is not available)           |
-+----------------------------+-------+---------------------------------------+
-| :data:`.MPI_CONFIGURATION` | Dict  | MPI configuration                     |
-+----------------------------+-------+---------------------------------------+
-| :data:`.MPI_COMM_WORLD`    |       | ``mpi4py.MPI.COMM_WORLD`` or ``None`` |
-+----------------------------+-------+---------------------------------------+
 
-The fact that :data:`.MPI_SIZE` and :data:`.MPI_RANK` are defined even
-if ``mpi4py`` was not imported should make the creation of analysis
-codes easier.
+Enabling/disabling MPI
+----------------------
+
+The user can control whether MPI must be used or not in a script,
+through the environment variable ``LITEBIRD_SIM_PI`` (``ENABLE_MPI``
+is accepted as well):
+
+- If the variable is set to the empty string or to ``1``, ``true``,
+  ``on``, ``yes``, then ``mpi4py`` is imported, and an exception is
+  raised if this cannot be done (e.g., because it was not installed
+  using the flag ``--extra=mpi`` when ``poetry install`` was called).
+
+- If the variable is set to ``0``, ``false``, ``off`` or ``no``, then
+  ``mpi4py`` is *not* imported, even if it is installed.
+
+- If the variable is not set, then ``mpi4py`` will be imported, but
+  any failure will be accepted and the framework will silently switch
+  to serial mode.
 
 
 API reference

--- a/docs/source/mpi.rst
+++ b/docs/source/mpi.rst
@@ -1,0 +1,42 @@
+.. _using_mpi:
+
+Using MPI
+=========
+
+The LiteBIRD Simulation Framework lists mpi4py as an *optional*
+dependency. This means that simulation codes should be able to cope
+with the lack of MPI.
+
+The following table lists the variable that can be used to detect if
+MPI is present or not:
+
+
++----------------------------+-------+---------------------------------------+
+| Variable                   | Value | Meaning                               |
++----------------------------+-------+---------------------------------------+
+| :data:`.HAVE_MPI4PY`       | Bool  | ``True`` if mpi4py was imported       |
++----------------------------+-------+---------------------------------------+
+| :data:`.MPI_RANK`          | Int   | Rank of current MPI process, in       |
+|                            |       | the range ``0 … MPI_SIZE - 1``        |
+|                            |       | (0 if MPI is not available)           |
++----------------------------+-------+---------------------------------------+
+| :data:`.MPI_SIZE`          | Int   | Number of available MPI processes     |
+|                            |       | (1 if MPI is not available)           |
++----------------------------+-------+---------------------------------------+
+| :data:`.MPI_CONFIGURATION` | Dict  | MPI configuration                     |
++----------------------------+-------+---------------------------------------+
+| :data:`.MPI_COMM_WORLD`    |       | ``mpi4py.MPI.COMM_WORLD`` or ``None`` |
++----------------------------+-------+---------------------------------------+
+
+The fact that :data:`.MPI_SIZE` and :data:`.MPI_RANK` are defined even
+if ``mpi4py`` was not imported should make the creation of analysis
+codes easier.
+
+
+API reference
+-------------
+
+.. automodule:: litebird_sim.mpi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/simulations.rst
+++ b/docs/source/simulations.rst
@@ -1,7 +1,75 @@
 Simulations
 ===========
 
-Describe how to use a :class:`.Simulation` object.
+The LiteBIRD Simulation Framework is built on the :class:`.Simulation`
+class, which should be instantiated in any pipeline built using this
+framework. The class acts as a container for the many analysis modules
+available to the user, and it offers the following features:
+
+1. Provenance model;
+2. Interface with the instrument database;
+3. System abstractions;
+4. Generation of reports.
+
+Provenance model
+----------------
+
+A «provenance model» is, generally speaking, a way to track the
+history and origin of a data set by recording the following
+information:
+
+1. Who or what created the dataset?
+2. Which algorithm or instrumentation was used to produce it?
+3. Which steps were undertaken to process the raw data?
+4. How can one get access to the raw samples used to produce the
+   dataset?
+
+The LiteBIRD Simulation Framework tracks these information using
+parameter files (in TOML format) and generating reports at the end of
+a simulation.
+
+
+Interface with the instrument database
+--------------------------------------
+
+To simulation LiteBIRD's data acquisition, the simulation code must be
+aware of the characteristics of the instrument. These are specified in
+the LiteBIRD Instrument Model (IMO) database, which can be accessed by
+people with sufficient rights. This Simulation Framework has the
+ability to access the database and take the input parameters necessary
+for its analysis modules to produce the expected output.
+
+   
+System abstractions
+-------------------
+
+In some cases, simulations must be ran on HPC computers, distributing
+the job on many processing units; in other cases, a simple laptop
+might be enough. The LiteBIRD Simulation Framework uses MPI to
+parallelize its codes, which is however an optional dependency: the
+code can be ran serially.
+
+When creating a :class:`.Simulation` object, the user can tell the
+framework to use or not MPI using the flag `use_mpi`::
+
+  import litebird_sim as lbs
+
+  # This simulation must be ran using MPI
+  sim = lbs.Simulation(use_mpi = True)
+
+The framework sets a number of variables related to MPI; these
+variables are *always* defined, even if MPI is not available, and they
+can be used to make the code work in different situations. If your
+code must be able to run both with and without MPI, you should
+initialize a :class:`.Simulation` object using the variable
+:class:`.HAVE_MPI4PY`::
+
+  import litebird_sim as lbs
+
+  # This simulation can take advantage of MPI, if present
+  sim = lbs.Simulation(use_mpi = lbs.HAVE_MPI4PY)
+         
+See the page :ref:`using_mpi` for more information.
 
 
 Generation of reports

--- a/litebird_sim/__init__.py
+++ b/litebird_sim/__init__.py
@@ -1,5 +1,7 @@
 # -*- encoding: utf-8 -*-
 
+from .distribute import distribute_evenly, distribute_optimally
+from .detectors import Detector
 from .healpix import (
     nside_to_npix,
     npix_to_nside,
@@ -9,9 +11,8 @@ from .healpix import (
     write_healpix_map_to_hdu,
     write_healpix_map_to_file,
 )
-from .distribute import distribute_evenly, distribute_optimally
+from .mpi import HAVE_MPI4PY, MPI_RANK, MPI_SIZE, MPI_COMM_WORLD, MPI_CONFIGURATION
 from .observations import Observation
-from .detectors import Detector
 from .simulations import Simulation
 
 __author__ = "The LiteBIRD simulation team"
@@ -28,6 +29,12 @@ __all__ = [
     # distribute.py
     "distribute_evenly",
     "distribute_optimally",
+    # mpi.py
+    "HAVE_MPI4PY",
+    "MPI_RANK",
+    "MPI_SIZE",
+    "MPI_CONFIGURATION",
+    "MPI_COMM_WORLD",
     # observations.py
     "Observation",
     # detectors.py

--- a/litebird_sim/__init__.py
+++ b/litebird_sim/__init__.py
@@ -11,7 +11,7 @@ from .healpix import (
     write_healpix_map_to_hdu,
     write_healpix_map_to_file,
 )
-from .mpi import MpiWrapper, MPI_COMM_WORLD
+from .mpi import MPI_COMM_WORLD, MPI_ENABLED, MPI_CONFIGURATION
 from .observations import Observation
 from .simulations import Simulation
 
@@ -30,8 +30,9 @@ __all__ = [
     "distribute_evenly",
     "distribute_optimally",
     # mpi.py
-    "MpiWrapper",
     "MPI_COMM_WORLD",
+    "MPI_ENABLED",
+    "MPI_CONFIGURATION",
     # observations.py
     "Observation",
     # detectors.py

--- a/litebird_sim/__init__.py
+++ b/litebird_sim/__init__.py
@@ -11,7 +11,7 @@ from .healpix import (
     write_healpix_map_to_hdu,
     write_healpix_map_to_file,
 )
-from .mpi import HAVE_MPI4PY, MPI_RANK, MPI_SIZE, MPI_COMM_WORLD, MPI_CONFIGURATION
+from .mpi import MpiWrapper, MPI_COMM_WORLD
 from .observations import Observation
 from .simulations import Simulation
 
@@ -30,10 +30,7 @@ __all__ = [
     "distribute_evenly",
     "distribute_optimally",
     # mpi.py
-    "HAVE_MPI4PY",
-    "MPI_RANK",
-    "MPI_SIZE",
-    "MPI_CONFIGURATION",
+    "MpiWrapper",
     "MPI_COMM_WORLD",
     # observations.py
     "Observation",

--- a/litebird_sim/__init__.py
+++ b/litebird_sim/__init__.py
@@ -9,12 +9,15 @@ from .healpix import (
     write_healpix_map_to_hdu,
     write_healpix_map_to_file,
 )
+from .distribute import distribute_evenly, distribute_optimally
 from .observations import Observation
+from .detectors import Detector
 from .simulations import Simulation
 
 __author__ = "The LiteBIRD simulation team"
 __version__ = "0.1.0"
 __all__ = [
+    # healpix.py
     "nside_to_npix",
     "npix_to_nside",
     "is_npix_ok",
@@ -22,6 +25,13 @@ __all__ = [
     "get_pixel_format",
     "write_healpix_map_to_hdu",
     "write_healpix_map_to_file",
+    # distribute.py
+    "distribute_evenly",
+    "distribute_optimally",
+    # observations.py
     "Observation",
+    # detectors.py
+    "Detector",
+    # simulations.py
     "Simulation",
 ]

--- a/litebird_sim/detectors.py
+++ b/litebird_sim/detectors.py
@@ -1,0 +1,30 @@
+# -*- encoding: utf-8 -*-
+
+
+class Detector:
+    def __init__(
+        self, imo=None, name=None, beam_z=None, sampfreq_hz=None, simulation=None
+    ):
+        # Basic check
+        if (not imo) and (not name) and (not beam_z) and not (sampfreq_hz):
+            raise ValueError(
+                "You must provide some arguments to a Detector's constructor"
+            )
+
+        self.simulation = simulation
+
+        if imo:
+            assert self.simulation, (
+                "You must provide a Simulation object if you plan to "
+                "interface to the IMO"
+            )
+
+            metadata, obj = self.simulation.query_object(imo)
+
+        else:
+            self.name = name
+            self.beam_z = beam_z
+            self.sampfreq_hz = sampfreq_hz
+
+    def read_def_from_imo(self, imo_url):
+        raise NotImplementedError()

--- a/litebird_sim/distribute.py
+++ b/litebird_sim/distribute.py
@@ -101,18 +101,8 @@ def _num_of_workers(arr, n, maxLen, weight_fn):
 
 
 def _find_max_and_sum(arr, weight_fn):
-    max_value = None
-    sum_value = 0
-    for cur_element in arr:
-        cur_weight = weight_fn(cur_element)
-        if not max_value:
-            max_value = cur_weight
-        elif max_value < cur_weight:
-            max_value = cur_weight
-
-        sum_value += cur_weight
-
-    return (max_value, sum_value)
+    weights = list(map(weight_fn, arr))
+    return (max(weights), sum(weights))
 
 
 def _partition(arr, n, k, weight_fn):

--- a/litebird_sim/distribute.py
+++ b/litebird_sim/distribute.py
@@ -22,11 +22,11 @@ def distribute_evenly(num_of_elements, num_of_groups):
 
     .. doctest::
 
-      >>> distribute_evenly(8, 3)
-      [(0, 3), (3, 3), (6, 2)]
+      >>> distribute_evenly(5, 2)
+      [Span(start_idx=0, num_of_elements=3), Span(start_idx=3, num_of_elements=2)]
 
-      >>> distribute_evenly(2, 3)
-      [(0, 1), (1, 1), (2, 0)]
+      >>> distribute_evenly(1, 2)
+      [Span(start_idx=0, num_of_elements=1), Span(start_idx=1, num_of_elements=0)]
 
     Args:
         num_of_elements (int): The number of elements to distribute
@@ -159,7 +159,7 @@ def distribute_optimally(elements, num_of_groups, weight_fn=None):
       >>> distribute_optimally([10, 10, 10, 10], 2)
       [Span(start_idx=0, num_of_elements=2), Span(start_idx=2, num_of_elements=2)]
 
-      >>> distribute_optimally([10, 10, 10, 10], 2)
+      >>> distribute_optimally([10, 10, 10, 20], 2)
       [Span(start_idx=0, num_of_elements=3), Span(start_idx=3, num_of_elements=1)]
 
       >>> distribute_optimally([40, 10, 10, 10], 2)

--- a/litebird_sim/distribute.py
+++ b/litebird_sim/distribute.py
@@ -1,0 +1,215 @@
+# -*- encoding: utf-8 -*-
+
+from collections import namedtuple
+
+Span = namedtuple("Span", ["start_idx", "num_of_elements"])
+"""A sub-range in a sequence of elements.
+
+It has two fields: `start_idx` and `num_of_elements`.
+
+"""
+
+
+def distribute_evenly(num_of_elements, num_of_groups):
+    """Evenly distribute a set of equal elements between groups.
+
+    Assuming that we have `num_of_elements` objects that we want to
+    assign to `num_of_groups` separate groups, this function proposes
+    a distribution that tries to assign the most uniform number of
+    elements to each group.
+
+    This function works even if ``num_of_elements < num_of_groups``.
+
+    .. doctest::
+
+      >>> distribute_evenly(8, 3)
+      [(0, 3), (3, 3), (6, 2)]
+
+      >>> distribute_evenly(2, 3)
+      [(0, 1), (1, 1), (2, 0)]
+
+    Args:
+        num_of_elements (int): The number of elements to distribute
+        num_of_groups (int): The number of groups to use in the result
+
+    Returns:
+        a list of 2-element tuples containing `num_of_groups`
+        elements, each of them being a 2-element tuple containing (1)
+        the index of the element in the group and (2) the number of
+        elements in the group. Being named tuples, you can access the
+        index using the field name ``start_idx``, and the number of
+        elements using the name ``num_of_elements``.
+
+    """
+    assert num_of_elements > 0
+    assert num_of_groups > 0
+
+    base_length = num_of_elements // num_of_groups
+    leftovers = num_of_elements % num_of_groups
+
+    # If leftovers == 0, then the number of elements is divided evenly
+    # by num_of_groups, and the solution is trivial. If it's not, then
+    # each of the "leftoverss" is placed in one of the first groups.
+    #
+    # Example: let's split 8 elements in 3 groups. In this case,
+    # base_length=2 and leftovers=2 (elements #7 and #8):
+    #
+    # +----+----+----+  +----+----+----+  +----+----+
+    # | #1 | #2 | #3 |  | #4 | #5 | #6 |  | #7 | #8 |
+    # +----+----+----+  +----+----+----+  +----+----+
+    #
+    #
+
+    result = []
+    for i in range(num_of_groups):
+        if i < leftovers:
+            # Make place for one of the leftovers
+            cur_length = base_length + 1
+            cur_pos = cur_length * i
+        else:
+            # No need to accomodate for leftovers, but consider their
+            # presence in fixing the starting position for this group
+            cur_length = base_length
+            cur_pos = base_length * i + leftovers
+
+        result.append(Span(start_idx=cur_pos, num_of_elements=cur_length))
+
+    assert len(result) == num_of_groups
+    assert sum([pair.num_of_elements for pair in result]) == num_of_elements
+    return result
+
+
+# The following implementation of the painter's partition problem is
+# heavily inspired by the code at
+# https://www.geeksforgeeks.org/painters-partition-problem-set-2/?ref=rp
+
+
+def _num_of_workers(arr, n, maxLen, weight_fn):
+    total = 0
+    num_of_workers = 1
+
+    for cur_element in arr:
+        cur_weight = weight_fn(cur_element)
+        total += cur_weight
+
+        if total > maxLen:
+            num_of_workers += 1
+            # Reset "total" for the next worker
+            total = cur_weight
+
+    return num_of_workers
+
+
+def _find_max_and_sum(arr, weight_fn):
+    max_value = None
+    sum_value = 0
+    for cur_element in arr:
+        cur_weight = weight_fn(cur_element)
+        if not max_value:
+            max_value = cur_weight
+        elif max_value < cur_weight:
+            max_value = cur_weight
+
+        sum_value += cur_weight
+
+    return (max_value, sum_value)
+
+
+def _partition(arr, n, k, weight_fn):
+    lo, hi = _find_max_and_sum(arr, weight_fn)
+
+    while lo < hi:
+        mid = lo + (hi - lo) / 2
+        required_workers = _num_of_workers(arr, n, mid, weight_fn)
+
+        # find better optimum in lower half
+        # here mid is included because we
+        # may not get anything better
+        if required_workers <= k:
+            hi = mid
+
+        # find better optimum in upper half
+        # here mid is excluded because it gives
+        # required Painters > k, which is invalid
+        else:
+            lo = mid + 1
+
+    # required
+    return lo
+
+
+def __identity_fn(x):
+    return x
+
+
+def distribute_optimally(elements, num_of_groups, weight_fn=None):
+    """Evenly distribute a set of equal elements between groups.
+
+    Assuming that we have a set of elements, each having its own
+    weight that is computed using `weight_fn` (i.e., for any element
+    ``x`` in ``elements``, its weight is ``weight_fn(x)``), this
+    function proposes a distribution that tries to assign the elements
+    to each group so that the weight in each group is more or less the
+    same.
+
+    This function works even if ``num_of_elements < num_of_groups``.
+
+    .. doctest::
+
+      >>> distribute_optimally([10, 10, 10, 10], 2)
+      [Span(start_idx=0, num_of_elements=2), Span(start_idx=2, num_of_elements=2)]
+
+      >>> distribute_optimally([10, 10, 10, 10], 2)
+      [Span(start_idx=0, num_of_elements=3), Span(start_idx=3, num_of_elements=1)]
+
+      >>> distribute_optimally([40, 10, 10, 10], 2)
+      [Span(start_idx=0, num_of_elements=1), Span(start_idx=1, num_of_elements=3)]
+
+      >>> distribute_optimally([('a', 10), ('b', 10), ('c', 10)], 2, lambda x: x[1])
+      [Span(start_idx=0, num_of_elements=2), Span(start_idx=2, num_of_elements=1)]
+
+    This function is a generalization of :meth:`.distribute_evenly`;
+    in that case, the function assumes that each element weights
+    equally.
+
+    Args:
+        elements (list): A list of objects to be split in groups
+        num_of_groups (int): The number of groups to use in the result
+        weight_fn: A function-like object that computes the weight
+            given one of the objects in `elements`. If unspecified, the
+            identity function will be used.
+
+    Returns:
+        a list of 2-element tuples containing `num_of_groups`
+        elements, each of them being a 2-element tuple containing (1)
+        the index of the element in the group and (2) the number of
+        elements in the group. Being named tuples, you can access the
+        index using the field name ``start_idx``, and the number of
+        elements using the name ``num_of_elements``.
+
+    """
+    if not weight_fn:
+        weight_fn = __identity_fn
+
+    max_weight = _partition(elements, len(elements), num_of_groups, weight_fn)
+
+    result = []
+    start_idx = 0
+    weight = 0
+    cur_num = 0
+    for cur_idx, cur_element in enumerate(elements):
+        cur_weight = weight_fn(cur_element)
+        if weight + cur_weight > max_weight:
+            result.append(Span(start_idx=start_idx, num_of_elements=cur_num))
+            cur_num = 1
+            weight = cur_weight
+            start_idx = cur_idx
+        else:
+            weight += cur_weight
+            cur_num += 1
+
+    result.append(Span(start_idx=start_idx, num_of_elements=cur_num))
+
+    assert len(result) == num_of_groups
+    assert sum([r.num_of_elements for r in result]) == len(elements)
+    return result

--- a/litebird_sim/healpix.py
+++ b/litebird_sim/healpix.py
@@ -99,16 +99,16 @@ def map_type(pixels):
     if npix is not None:
         for p in pixels[1:]:
             if len(p) != npix:
-                raise TypeError("input maps have different npix")
+                return -1
         if is_npix_ok(len(pixels[0])):
             return len(pixels)
         else:
-            raise TypeError("bad number of pixels")
+            return -1
     else:
         if is_npix_ok(len(pixels)):
             return 0
         else:
-            raise TypeError("bad number of pixels")
+            return -1
 
 
 def get_pixel_format(t):
@@ -127,8 +127,9 @@ def get_pixel_format(t):
 
     .. doctest::
 
+        >>> import numpy
         >>> get_pixel_format(numpy.uint8)
-        "B"
+        'B'
 
     """
     conv = {
@@ -241,18 +242,19 @@ def write_healpix_map_to_hdu(
     or ``(NAME, VALUE, COMMENT)``. These pairs are used to save
     additional metadata in the header of the FITS HDU.
 
-    .. doctest::
+    Here is an example::
 
-        >>> hdu = write_healpix_map_to_hdu(
-               [
-                   np.zeros(12),   # I map
-                   np.zeros(12),   # Q map
-                   np.zeros(12),   # U map
-               ],
-               column_names=["I", "Q", "U"],
-               column_units=["K", "mK", "mK"],
-               dtype=[np.float64, np.float32, np.float32],
-               name="MYMAP")
+        import numpy
+        hdu = write_healpix_map_to_hdu(
+           [
+               numpy.zeros(12),   # I map
+               numpy.zeros(12),   # Q map
+               numpy.zeros(12),   # U map
+           ],
+           column_names=["I", "Q", "U"],
+           column_units=["K", "mK", "mK"],
+           dtype=[np.float64, np.float32, np.float32],
+           name="MYMAP")
     """
 
     if not hasattr(pixels, "__len__"):
@@ -266,7 +268,9 @@ def write_healpix_map_to_hdu(
         except AttributeError:
             pass
 
-    if map_type(pixels) == 0:  # a single map is converted to a list
+    this_map_type = map_type(pixels)
+    assert this_map_type != -1, "Invalid map"
+    if this_map_type == 0:  # a single map is converted to a list
         pixels = [pixels]
 
     # check the dtype and convert it
@@ -370,17 +374,18 @@ def write_healpix_map_to_file(
 
     .. doctest::
 
-        >>> write_healpix_map_to_file(
-               filename="out.fits.gz",
-               pixels=[
-                   np.zeros(12),   # I map
-                   np.zeros(12),   # Q map
-                   np.zeros(12),   # U map
-               ],
-               column_names=["I", "Q", "U"],
-               column_units=["K", "mK", "mK"],
-               dtype=[np.float64, np.float32, np.float32],
-               name="MYMAP")
+        import numpy
+        write_healpix_map_to_file(
+           filename="out.fits.gz",
+           pixels=[
+               numpy.zeros(12),   # I map
+               numpy.zeros(12),   # Q map
+               numpy.zeros(12),   # U map
+           ],
+           column_names=["I", "Q", "U"],
+           column_units=["K", "mK", "mK"],
+           dtype=[np.float64, np.float32, np.float32],
+           name="MYMAP")
     """
     hdu = write_healpix_map_to_hdu(
         pixels=pixels,

--- a/litebird_sim/mpi.py
+++ b/litebird_sim/mpi.py
@@ -4,15 +4,41 @@ try:
     import mpi4py
     from mpi4py import MPI
 
+    #: Set to True if MPI is available through mpi4py
     HAVE_MPI4PY = True
+
+    #: If MPI is available, this is the rank of the current process,
+    #: otherwise it's zero
     MPI_RANK = MPI.COMM_WORLD.rank
+
+    #: If MPI is available, this is the number of MPI processes
+    #: currently running, otherwise it's 1.
     MPI_SIZE = MPI.COMM_WORLD.size
+
+    #: Either a dictionary containing the mpi4py configuration, or
+    #: ``None`` if mpi4py is not available
     MPI_CONFIGURATION = mpi4py.get_config()
+
+    #: Either the constant ``mpi4py.MPI.COMM_WORLD``, or ``None``
+    #: if mpi4py is not available
     MPI_COMM_WORLD = MPI.COMM_WORLD
 
 except ModuleNotFoundError:
+    #: Set to True if MPI is available through mpi4py
     HAVE_MPI4PY = False
+
+    #: If MPI is available, this is the rank of the current process,
+    #: otherwise it's zero
     MPI_RANK = 0
+
+    #: If MPI is available, this is the number of MPI processes
+    #: currently running, otherwise it's 1.
     MPI_SIZE = 1
+
+    #: Either a dictionary containing the mpi4py configuration, or
+    #: ``None`` if mpi4py is not available
     MPI_CONFIGURATION = None
+
+    #: Either the constant ``mpi4py.MPI.COMM_WORLD``, or ``None``
+    #: if mpi4py is not available
     MPI_COMM_WORLD = None

--- a/litebird_sim/mpi.py
+++ b/litebird_sim/mpi.py
@@ -1,0 +1,13 @@
+# -*- encoding: utf-8 -*-
+
+try:
+    from mpi4py import MPI
+
+    HAVE_MPI4PY = True
+    MPI_RANK = MPI.COMM_WORLD.rank
+    MPI_SIZE = MPI.COMM_WORLD.size
+
+except ModuleNotFoundError:
+    HAVE_MPI4PY = False
+    MPI_RANK = 0
+    MPI_SIZE = 1

--- a/litebird_sim/mpi.py
+++ b/litebird_sim/mpi.py
@@ -1,13 +1,18 @@
 # -*- encoding: utf-8 -*-
 
 try:
+    import mpi4py
     from mpi4py import MPI
 
     HAVE_MPI4PY = True
     MPI_RANK = MPI.COMM_WORLD.rank
     MPI_SIZE = MPI.COMM_WORLD.size
+    MPI_CONFIGURATION = mpi4py.get_config()
+    MPI_COMM_WORLD = MPI.COMM_WORLD
 
 except ModuleNotFoundError:
     HAVE_MPI4PY = False
     MPI_RANK = 0
     MPI_SIZE = 1
+    MPI_CONFIGURATION = None
+    MPI_COMM_WORLD = None

--- a/litebird_sim/mpi.py
+++ b/litebird_sim/mpi.py
@@ -1,44 +1,92 @@
 # -*- encoding: utf-8 -*-
 
-try:
-    import mpi4py
-    from mpi4py import MPI
+import os
 
-    #: Set to True if MPI is available through mpi4py
-    HAVE_MPI4PY = True
 
-    #: If MPI is available, this is the rank of the current process,
-    #: otherwise it's zero
-    MPI_RANK = MPI.COMM_WORLD.rank
+class MpiWrapper:
+    """Wrap optional MPI functionalities into a class.
 
-    #: If MPI is available, this is the number of MPI processes
-    #: currently running, otherwise it's 1.
-    MPI_SIZE = MPI.COMM_WORLD.size
+    This class is used to create the global variable
+    :data:`MPI_COMM_WORLD`, which should be used whenever the code
+    provides optional support for MPI.
 
-    #: Either a dictionary containing the mpi4py configuration, or
-    #: ``None`` if mpi4py is not available
-    MPI_CONFIGURATION = mpi4py.get_config()
+    The class behaves like ``mpi4py.MPI``, if ``mpi4py`` can be
+    imported, wrapping all the usual functions (``sendv``, ``recv``,
+    ``gather``, ``reduce``, etc.). It provides a few additional
+    members:
 
-    #: Either the constant ``mpi4py.MPI.COMM_WORLD``, or ``None``
-    #: if mpi4py is not available
-    MPI_COMM_WORLD = MPI.COMM_WORLD
+    - ``configuration`` (dict): the result of ``mpi4py.get_config``
+    - ``have_mpi`` (bool): ``True`` if ``mpi4py`` is being used,
+    - ``False`` otherwise.
 
-except ModuleNotFoundError:
-    #: Set to True if MPI is available through mpi4py
-    HAVE_MPI4PY = False
+    If no MPI is available, the class defines the member variables
+    ``rank`` to 0 and ``size`` to 1. Using methods from
+    ``mpi4py.MPI.COMM_WORLD`` will result in a error.
 
-    #: If MPI is available, this is the rank of the current process,
-    #: otherwise it's zero
-    MPI_RANK = 0
+    The behavior of this class is affected by the environment
+    variables ``LITEBIRD_SIM_MPI`` and ``ENABLE_MPI``, which are
+    checked in this order: if they are set to a null value or a true
+    Boolean string (either ``1``, ``yes``, ``true``, or ``on``,
+    case-insensitive), then the presence of ``mpi4py`` is forced and
+    an exception is thrown if ``mpi4py`` cannot be imported. If they
+    are set to a false Boolean string, then ``mpi4py`` is not
+    imported. If no environment variable is found, the code tries to
+    import ``mpi4py`` but does not complain if it fails to do so.
 
-    #: If MPI is available, this is the number of MPI processes
-    #: currently running, otherwise it's 1.
-    MPI_SIZE = 1
+    """
 
-    #: Either a dictionary containing the mpi4py configuration, or
-    #: ``None`` if mpi4py is not available
-    MPI_CONFIGURATION = None
+    def __init__(self):
+        self.have_mpi = False
+        self.rank = 0
+        self.size = 1
+        self.configuration = {}
+        self.comm_world = None
 
-    #: Either the constant ``mpi4py.MPI.COMM_WORLD``, or ``None``
-    #: if mpi4py is not available
-    MPI_COMM_WORLD = None
+        env_enable = self._check_if_enable_mpi()
+        if env_enable in (None, True):
+            try:
+                import mpi4py
+                from mpi4py import MPI
+
+                self.have_mpi = True
+                self.rank = MPI.COMM_WORLD.rank
+                self.size = MPI.COMM_WORLD.size
+                self.configuration = mpi4py.get_config()
+                self.comm_world = MPI.COMM_WORLD
+            except ModuleNotFoundError:
+                if env_enable:
+                    raise  # Rethrow exception
+
+    @staticmethod
+    def _check_if_enable_mpi():
+        for keyword in ["LITEBIRD_SIM_MPI", "ENABLE_MPI"]:
+            if keyword not in os.environ:
+                continue
+
+            value = os.environ[keyword]
+            if value.lower() in ["1", "yes", "true", "on", ""]:
+                return True
+            if value.lower() in ["0", "no", "false", "off"]:
+                return False
+
+        return None
+
+    def __getattr__(self, attr):
+        # Forward any call to self.comm_world, which is equal to
+        # MPI.COMM_WORLD; in this way, MpiWrapper can respond to any
+        # method call that is available by MPI.COMM_WORLD (e.g.,
+        # `barrier`, `allreduce`, etc.)
+        if attr in dir(self.comm_world):
+            return getattr(self.comm_world, attr)
+        else:
+            raise AttributeError(
+                (
+                    "Neither 'MpiWrapper' nor 'MPI.COMM_WORLD' "
+                    + "have a member named '{}'"
+                ).format(attr)
+            )
+
+
+#: Global variable of type :class:`MpiWrapper`. Use this whenever you
+#: might want to use MPI
+MPI_COMM_WORLD = MpiWrapper()

--- a/litebird_sim/observations.py
+++ b/litebird_sim/observations.py
@@ -54,9 +54,9 @@ class Observation:
                 #    measures time in seconds (alongside with "unix"
                 #    and "gps")
                 #
-                # 2. Of the three choices, "cxcsec" uses a recent date
-                #    as reference (1998-01-01, vs. 1990-01-01 for
-                #    "gps" and 1980-01-06 for "unix").
+                # 2. Of the three choices, "cxcsec" uses the most
+                #    recent date as reference (1998-01-01, vs.
+                #    1990-01-01 for "gps" and 1980-01-06 for "unix").
                 self.start_time = start_time.cxcsec
         else:
             self.start_time = start_time

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -24,21 +24,6 @@ OutputFileRecord = namedtuple("OutputFileRecord", ["path", "description"])
 class Simulation:
     """A container object for running simulations
 
-    Args:
-
-        base_path (str or `pathlib.Path`): the folder that will
-            contain the output. If this folder does not exist and the
-            user has sufficient rights, it will be created.
-
-        name (str): a string identifying the simulation. This will
-            be used in the reports.
-
-        use_mpi (bool): a Boolean flag specifying if the simulation
-            should take advantage of MPI or not.
-
-        description (str): a (possibly long) description of the
-            simulation, to be put in the report saved in `base_path`).
-
     This is the most important class in the Litebird_sim framework. It
     initializes an output directory that will contain all the products
     of a simulation and will handle the generation of reports and
@@ -54,6 +39,10 @@ class Simulation:
         sim = litebird_sim.Simulation(name="My simulation")
         print(f"Running {sim.name}, saving results in {sim.base_path}")
 
+    The member variable `observations` is a list of
+    :class:`.Observation` objects, which is initialized by the methods
+    :meth:`.create_observations` (when ``distribute=True``) and
+    :meth:`.distribute_workload`.
 
     This class keeps track of any output file saved in `base_path`
     through the member variable `self.list_of_outputs`. This is a list
@@ -64,6 +53,23 @@ class Simulation:
         for curpath, curdescr in sim.list_of_outputs:
             print(f"{curpath}: {curdescr}")
 
+    Args:
+
+        base_path (str or `pathlib.Path`): the folder that will
+            contain the output. If this folder does not exist and the
+            user has sufficient rights, it will be created.
+
+        name (str): a string identifying the simulation. This will
+            be used in the reports.
+
+        use_mpi (bool): a Boolean flag specifying if the simulation
+            should take advantage of MPI or not. If this flag is set
+            to ``True`` but MPI is not available, a ``RuntimeError``
+            exception will be raised.
+
+        description (str): a (possibly long) description of the
+            simulation, to be put in the report saved in `base_path`).
+
     """
 
     def __init__(
@@ -71,6 +77,10 @@ class Simulation:
     ):
         self.base_path = Path(base_path)
         self.name = name
+
+        if use_mpi and not HAVE_MPI4PY:
+            raise RuntimeError("use_mpi=True, but MPI is not available")
+
         self.use_mpi = use_mpi and HAVE_MPI4PY
         if use_mpi:
             self.mpi_rank = MPI_RANK

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -239,9 +239,7 @@ class Simulation:
         for detidx, cur_det in enumerate(detectors):
             cur_sampfreq_hz = cur_det.sampfreq_hz
             num_of_samples = cur_sampfreq_hz * duration_s
-            samples_per_obs = distribute_evenly(
-                num_of_samples[detidx], num_of_obs_per_detector
-            )
+            samples_per_obs = distribute_evenly(num_of_samples, num_of_obs_per_detector)
 
             if isinstance(start_time, float):
                 cur_time = start_time
@@ -279,8 +277,12 @@ class Simulation:
             return
 
         cur_rank = self.mpi_rank
-        self.observations = distribute_optimally(
+        span = distribute_optimally(
             elements=observations,
             num_of_groups=self.mpi_size,
-            worker_fn=lambda obs: obs.nsamples,
+            weight_fn=lambda obs: obs.nsamples,
         )[cur_rank]
+
+        self.observations = observations[
+            span.start_idx : (span.start_idx + span.num_of_elements)
+        ]

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -9,7 +9,6 @@ from shutil import copyfile, copytree
 from .detectors import Detector
 from .distribute import distribute_evenly, distribute_optimally
 from .healpix import write_healpix_map_to_file
-from .mpi import MPI_COMM_WORLD
 from .observations import Observation
 
 from astropy.time import Time, TimeDelta
@@ -33,7 +32,7 @@ class Simulation:
     completed. This ensures that all the information are saved to disk
     before the completion of your script.
 
-    You can access the fields `base_path`, `name`, `use_mpi`, and
+    You can access the fields `base_path`, `name`, `mpi_comm`, and
     `description` in the `Simulation` object::
 
         sim = litebird_sim.Simulation(name="My simulation")
@@ -62,10 +61,8 @@ class Simulation:
         name (str): a string identifying the simulation. This will
             be used in the reports.
 
-        use_mpi (bool): a Boolean flag specifying if the simulation
-            should take advantage of MPI or not. If this flag is set
-            to ``True`` but MPI is not available, a ``RuntimeError``
-            exception will be raised.
+        mpi_comm: either `None` (do not use MPI) or a MPI communicator
+            object, like `mpi4py.MPI.COMM_WORLD`.
 
         description (str): a (possibly long) description of the
             simulation, to be put in the report saved in `base_path`).
@@ -73,16 +70,12 @@ class Simulation:
     """
 
     def __init__(
-        self, base_path=Path(), name=None, use_mpi=False, description="",
+        self, base_path=Path(), name=None, mpi_comm=None, description="",
     ):
         self.base_path = Path(base_path)
         self.name = name
 
-        if use_mpi and not MPI_COMM_WORLD.have_mpi:
-            raise RuntimeError("use_mpi=True, but MPI is not available")
-
-        self.use_mpi = use_mpi and MPI_COMM_WORLD.have_mpi
-        self.mpi_comm = MPI_COMM_WORLD
+        self.mpi_comm = mpi_comm
 
         self.observations = []
 

--- a/test/mpi/test_mpi.py
+++ b/test/mpi/test_mpi.py
@@ -4,14 +4,14 @@ import litebird_sim as lbs
 
 
 def test_distribution():
-    assert isinstance(lbs.HAVE_MPI4PY, bool)
+    comm_world = lbs.MPI_COMM_WORLD
 
-    if lbs.MPI_RANK == 0:
-        print(f"MPI_CONFIGURATION = {lbs.MPI_CONFIGURATION}")
+    if comm_world.rank == 0:
+        print(f"MPI configuration: {comm_world.configuration}")
 
-    sim = lbs.Simulation(use_mpi=lbs.HAVE_MPI4PY)
+    sim = lbs.Simulation(use_mpi=comm_world.have_mpi)
     det1 = lbs.Detector(name="pol01", beam_z=[0, 0, 1], sampfreq_hz=5, simulation=sim)
-    det2 = lbs.Detector(name="pol01", beam_z=[0, 0, 1], sampfreq_hz=50, simulation=sim)
+    det2 = lbs.Detector(name="pol02", beam_z=[0, 0, 1], sampfreq_hz=50, simulation=sim)
     sim.create_observations(
         [det1, det2],
         num_of_obs_per_detector=10,
@@ -23,8 +23,8 @@ def test_distribution():
         sim.observations
     ), "No observations have been defined for process {lbs.MPI_RANK + 1}/{lbs.MPI_SIZE}"
 
-    if lbs.MPI_SIZE > 1:
-        allobs = lbs.MPI_COMM_WORLD.allreduce(sim.observations)
+    if comm_world.size > 1:
+        allobs = comm_world.allreduce([x.detector.name for x in sim.observations])
     else:
         allobs = sim.observations
 

--- a/test/mpi/test_mpi.py
+++ b/test/mpi/test_mpi.py
@@ -1,0 +1,38 @@
+# -*- encoding: utf-8 -*-
+
+import litebird_sim as lbs
+
+
+def test_distribution():
+    assert isinstance(lbs.HAVE_MPI4PY, bool)
+
+    if lbs.MPI_RANK == 0:
+        print(f"MPI_CONFIGURATION = {lbs.MPI_CONFIGURATION}")
+
+    sim = lbs.Simulation(use_mpi=lbs.HAVE_MPI4PY)
+    det1 = lbs.Detector(name="pol01", beam_z=[0, 0, 1], sampfreq_hz=5, simulation=sim)
+    det2 = lbs.Detector(name="pol01", beam_z=[0, 0, 1], sampfreq_hz=50, simulation=sim)
+    sim.create_observations(
+        [det1, det2],
+        num_of_obs_per_detector=10,
+        start_time=0.0,
+        duration_s=86400.0 * 10,
+    )
+
+    assert (
+        sim.observations
+    ), "No observations have been defined for process {lbs.MPI_RANK + 1}/{lbs.MPI_SIZE}"
+
+    if lbs.MPI_SIZE > 1:
+        allobs = lbs.MPI_COMM_WORLD.allreduce(sim.observations)
+    else:
+        allobs = sim.observations
+
+    assert len(allobs) == 20
+
+
+def main():
+    test_distribution()
+
+
+main()

--- a/test/mpi/test_mpi.py
+++ b/test/mpi/test_mpi.py
@@ -7,9 +7,9 @@ def test_distribution():
     comm_world = lbs.MPI_COMM_WORLD
 
     if comm_world.rank == 0:
-        print(f"MPI configuration: {comm_world.configuration}")
+        print(f"MPI configuration: {lbs.MPI_CONFIGURATION}")
 
-    sim = lbs.Simulation(use_mpi=comm_world.have_mpi)
+    sim = lbs.Simulation(mpi_comm=comm_world)
     det1 = lbs.Detector(name="pol01", beam_z=[0, 0, 1], sampfreq_hz=5, simulation=sim)
     det2 = lbs.Detector(name="pol02", beam_z=[0, 0, 1], sampfreq_hz=50, simulation=sim)
     sim.create_observations(


### PR DESCRIPTION
This PR is a WIP. The aim is to implement a structure that permits to handle the distribution of the workload among MPI proceses. It tries to follow the same logic as TOAST, because it splits timelines into «observations»: in this way, integrating the code with TOAST should be (hopefully) as simple as possible.

Things to do:

- [X] Add a conditional dependency on `mpi4py`, so that the code can work with and without it
- [X] Add some functions to split a timeline between MPI processes
- [X] Modify the Travis CI build to test various MPI implementations under Linux and OSX (no MPI support for Windows is foreseen at the moment)
- [X] Add some documentation