### PR TITLE
Add healpy 1.13 as a dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -17,7 +17,7 @@ version = "1.4.3"
 [[package]]
 category = "main"
 description = "Disable App Nap on OS X 10.9"
-marker = "python_version >= \"3.3\" and sys_platform == \"darwin\" or platform_system == \"Darwin\""
+marker = "sys_platform == \"darwin\" or platform_system == \"Darwin\" or python_version >= \"3.3\" and sys_platform == \"darwin\""
 name = "appnope"
 optional = true
 python-versions = "*"
@@ -76,7 +76,6 @@ pytz = ">=2015.7"
 [[package]]
 category = "main"
 description = "Specifications for callback functions passed in to an API"
-marker = "python_version >= \"3.3\""
 name = "backcall"
 optional = true
 python-versions = "*"
@@ -214,6 +213,21 @@ pyflakes = ">=2.1.0,<2.2.0"
 
 [[package]]
 category = "main"
+description = "Healpix tools package for Python"
+name = "healpy"
+optional = false
+python-versions = "*"
+version = "1.13.0"
+
+[package.dependencies]
+astropy = "*"
+matplotlib = "*"
+numpy = ">=1.13"
+scipy = "*"
+six = "*"
+
+[[package]]
+category = "main"
 description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = true
@@ -326,7 +340,6 @@ test = ["pytest (>=3.6.0)", "pytest-cov", "mock"]
 [[package]]
 category = "main"
 description = "An autocompletion tool for Python that can be used for text editors."
-marker = "python_version >= \"3.3\""
 name = "jedi"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -736,7 +749,7 @@ six = "*"
 [[package]]
 category = "main"
 description = "Pexpect allows easy control of interactive console applications."
-marker = "python_version >= \"3.3\" and sys_platform != \"win32\""
+marker = "python_version >= \"3.3\" and sys_platform != \"win32\" or sys_platform != \"win32\""
 name = "pexpect"
 optional = true
 python-versions = "*"
@@ -748,7 +761,6 @@ ptyprocess = ">=0.5"
 [[package]]
 category = "main"
 description = "Tiny 'shelve'-like database with concurrency support"
-marker = "python_version >= \"3.3\""
 name = "pickleshare"
 optional = true
 python-versions = "*"
@@ -977,6 +989,17 @@ urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+
+[[package]]
+category = "main"
+description = "SciPy: Scientific Library for Python"
+name = "scipy"
+optional = false
+python-versions = ">=3.5"
+version = "1.4.1"
+
+[package.dependencies]
+numpy = ">=1.13.3"
 
 [[package]]
 category = "main"
@@ -1246,7 +1269,7 @@ jupyter = ["jupyter"]
 mpi = ["mpi4py"]
 
 [metadata]
-content-hash = "48a832e48b190efa5b4d699a18b9d713e9082796617fd1350c984b4a9e10371b"
+content-hash = "139ffd11ff479fa40180bd66bdc6317f985d89c3b2c12fdcb0cf61dbc28dfda4"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1347,6 +1370,21 @@ entrypoints = [
 flake8 = [
     {file = "flake8-3.7.9-py2.py3-none-any.whl", hash = "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"},
     {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
+]
+healpy = [
+    {file = "healpy-1.13.0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:ab3820dd7fb52a51fb666b204e6140be185ee90cbe09ff98de1aa9a7fff5bb8d"},
+    {file = "healpy-1.13.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:3c0b0a3eb1ea5299444d26a3e600e6b162fc139804ede36dd26c260faee3e835"},
+    {file = "healpy-1.13.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:05518207b9dd2021309bac13804c352427cd12eabb34b614f4bfef5e28646cd5"},
+    {file = "healpy-1.13.0-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:217a97aaf9b84f31137040355d442895344971a21c73a593a8156038cecc17ab"},
+    {file = "healpy-1.13.0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:bcbef9af7b71a8b757b11f04c2116d7c3f1e0e9f5567f2ff88a2f7bc4d21ede1"},
+    {file = "healpy-1.13.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6946367fac0747f2f6a329e6cf7fb6cfd9c1df8dc998c68eb1d84ee85c08c87b"},
+    {file = "healpy-1.13.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:bb5c90be006ebe62e98e8fe125bd734d7cdf8ec2530f7e54d05a87712f9ebf4e"},
+    {file = "healpy-1.13.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:f48c989bb7fe3eef472acf9bdf401629a72bc1f89023710a753f8ca636c332dc"},
+    {file = "healpy-1.13.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:c6b5ae4ad061a4eedbb92a4c89c855b8f6fe9efba1accbf25e5d22cdb7fd6477"},
+    {file = "healpy-1.13.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a409b59bd3e5d222318fa4a3f52dd58fe40e037704304ecba49ded8a1ec522af"},
+    {file = "healpy-1.13.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:190ba766b97bb9acb8da2bfe14317a23f0f514f41a222af3ce8cf6c014f30c44"},
+    {file = "healpy-1.13.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cbc5cc99bcb76cc0e9eacea1000709aa8ec9e5392e4797f43eabb2fc22012044"},
+    {file = "healpy-1.13.0.tar.gz", hash = "sha256:d0ae02791c2404002a09c643e9e50bc58e3d258f702c736dc1f39ce1e6526f73"},
 ]
 idna = [
     {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
@@ -1798,6 +1836,29 @@ qtpy = [
 requests = [
     {file = "requests-2.23.0-py2.py3-none-any.whl", hash = "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee"},
     {file = "requests-2.23.0.tar.gz", hash = "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"},
+]
+scipy = [
+    {file = "scipy-1.4.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:c5cac0c0387272ee0e789e94a570ac51deb01c796b37fb2aad1fb13f85e2f97d"},
+    {file = "scipy-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:a144811318853a23d32a07bc7fd5561ff0cac5da643d96ed94a4ffe967d89672"},
+    {file = "scipy-1.4.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:71eb180f22c49066f25d6df16f8709f215723317cc951d99e54dc88020ea57be"},
+    {file = "scipy-1.4.1-cp35-cp35m-win32.whl", hash = "sha256:770254a280d741dd3436919d47e35712fb081a6ff8bafc0f319382b954b77802"},
+    {file = "scipy-1.4.1-cp35-cp35m-win_amd64.whl", hash = "sha256:a1aae70d52d0b074d8121333bc807a485f9f1e6a69742010b33780df2e60cfe0"},
+    {file = "scipy-1.4.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:bb517872058a1f087c4528e7429b4a44533a902644987e7b2fe35ecc223bc408"},
+    {file = "scipy-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:dba8306f6da99e37ea08c08fef6e274b5bf8567bb094d1dbe86a20e532aca088"},
+    {file = "scipy-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:386086e2972ed2db17cebf88610aab7d7f6e2c0ca30042dc9a89cf18dcc363fa"},
+    {file = "scipy-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:8d3bc3993b8e4be7eade6dcc6fd59a412d96d3a33fa42b0fa45dc9e24495ede9"},
+    {file = "scipy-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:dc60bb302f48acf6da8ca4444cfa17d52c63c5415302a9ee77b3b21618090521"},
+    {file = "scipy-1.4.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:787cc50cab3020a865640aba3485e9fbd161d4d3b0d03a967df1a2881320512d"},
+    {file = "scipy-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0902a620a381f101e184a958459b36d3ee50f5effd186db76e131cbefcbb96f7"},
+    {file = "scipy-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:00af72998a46c25bdb5824d2b729e7dabec0c765f9deb0b504f928591f5ff9d4"},
+    {file = "scipy-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:9508a7c628a165c2c835f2497837bf6ac80eb25291055f56c129df3c943cbaf8"},
+    {file = "scipy-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a2d6df9eb074af7f08866598e4ef068a2b310d98f87dc23bd1b90ec7bdcec802"},
+    {file = "scipy-1.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3092857f36b690a321a662fe5496cb816a7f4eecd875e1d36793d92d3f884073"},
+    {file = "scipy-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:8a07760d5c7f3a92e440ad3aedcc98891e915ce857664282ae3c0220f3301eb6"},
+    {file = "scipy-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:1e3190466d669d658233e8a583b854f6386dd62d655539b77b3fa25bfb2abb70"},
+    {file = "scipy-1.4.1-cp38-cp38-win32.whl", hash = "sha256:cc971a82ea1170e677443108703a2ec9ff0f70752258d0e9f5433d00dda01f59"},
+    {file = "scipy-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:2cce3f9847a1a51019e8c5b47620da93950e58ebc611f13e0d11f4980ca5fecb"},
+    {file = "scipy-1.4.1.tar.gz", hash = "sha256:dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59"},
 ]
 send2trash = [
     {file = "Send2Trash-1.5.0-py3-none-any.whl", hash = "sha256:f1691922577b6fa12821234aeb57599d887c4900b9ca537948d2dac34aea888b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ markdown = "^3.2"
 matplotlib = "^3.1"
 markdown-katex = {version = "^201905.2-alpha.0", allow-prereleases = true}
 katex = "^0.0.4"
+healpy = "^1.13.0"
 [tool.poetry.extras]
 mpi = ["mpi4py"]
 docs = ["sphinx", "sphinx_rtd_theme"]


### PR DESCRIPTION
After having merged [PR#29](https://github.com/litebird/litebird_sim/pull/29), it should be possible to import Healpy without breaking the Appveyor script. This is fundamental to start implementing the pointing-generation module.