### PR TITLE
Fix readthedocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,8 +115,8 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
-# mkdocs documentation
-/site
+# documentation
+docs/build/
 
 # mypy
 .mypy_cache/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,5 @@ python:
       - requirements: docs/requirements.txt
    system_packages: true
 
-
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,9 +8,7 @@ python:
    version: 3.7
    install:
       - method: pip
-        path: .
-        extra_requirements:
-            - docs
+      - requirements: docs/requirements.txt
    system_packages: true
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx >=2.3,<3
+sphinx_rtd_theme >=0.4.3,<0.5
+sphinxcontrib-bibtex >=1,<2
+backports.datetime_fromisoformat


### PR DESCRIPTION
Currently the readthedocs builds are failing in <https://readthedocs.org/projects/litebird-sim/builds/12717715/>, as building ducc0 consume too much memory.

This PR attempt to fix it by installing minimally needed dep.

Obviously I can't test this as I can't push to readthedocs there.