### PR TITLE
Fix readthedocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,8 +115,8 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
-# mkdocs documentation
-/site
+# documentation
+docs/build/
 
 # mypy
 .mypy_cache/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,9 +8,7 @@ python:
    version: 3.7
    install:
       - method: pip
-        path: .
-        extra_requirements:
-            - docs
+      - requirements: docs/requirements.txt
    system_packages: true
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx >=2.3,<3
+sphinx_rtd_theme >=0.4.3,<0.5
+sphinxcontrib-bibtex >=1,<2
+backports.datetime_fromisoformat

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,14 @@
 sphinx >=2.3,<3
 sphinx_rtd_theme >=0.4.3,<0.5
 sphinxcontrib-bibtex >=1,<2
-backports.datetime_fromisoformat
+backports-datetime-fromisoformat >=1,<2
+sphinxcontrib-contentui >=0.2.5,<0.3
+numpy >=1.18,<2
+tomlkit >=0.5.8,<0.6
+numba >=0.51,<0.52
+astropy >=4,<5
+toml
+healpy >=1.13,<2
+pysm3 >=3.3,<4
+markdown >=3.2,<4
+markdown_katex >=202006.1021,<202007

--- a/litebird_sim/scanning.py
+++ b/litebird_sim/scanning.py
@@ -10,8 +10,6 @@ import astropy.units as u
 from numba import njit
 import numpy as np
 
-from ducc0.pointingprovider import PointingProvider
-
 from .imo import Imo
 
 from .quaternions import (
@@ -456,6 +454,8 @@ class Spin2EclipticQuaternions:
         must match that of `self.start_time`.
 
         """
+        from ducc0.pointingprovider import PointingProvider
+
         assert len(detector_quat) == 4
         assert (
             self.quats.shape[0] > 1


### PR DESCRIPTION
c.f. #89

Currently the readthedocs builds are failing in <https://readthedocs.org/projects/litebird-sim/builds/12717715/>, as building ducc0 consume too much memory.

This PR attempt to fix it by installing minimally needed dep.

I tested it locally and we'll see if it works on readthedocs.