### PR TITLE
Update dependency on ducc0 to 0.8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,6 @@ jobs:
           pip install poetry
           mkdir -p $HOME/.config/litebird_imo
           echo -e "[[repositories]]\nlocation = \"$(pwd)/test/mock_imo/\"\nname = \"Mock IMO\"" | tee $HOME/.config/litebird_imo/imo.toml
-        env:
-          DUCC0_OPTIMIZATION: none
 
       - name: Install litebird_sim
         run: |
@@ -38,6 +36,8 @@ jobs:
             EXTRAS="$EXTRAS -E mpi"
           fi
           poetry install $EXTRAS
+        env:
+          DUCC0_OPTIMIZATION: none
 
       - name: Tests
         run: sh ./bin/run_tests.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ jobs:
           pip install poetry
           mkdir -p $HOME/.config/litebird_imo
           echo -e "[[repositories]]\nlocation = \"$(pwd)/test/mock_imo/\"\nname = \"Mock IMO\"" | tee $HOME/.config/litebird_imo/imo.toml
+        env:
+          DUCC0_OPTIMIZATION: none
 
       - name: Install litebird_sim
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Version 0.2.0
 
+- Make tests run faster by using ducc0 0.8.0 [PR#92](https://github.com/litebird/litebird_sim/pull/92)
+
 - Misc minor changes: gitignore .DS_Store; losslessly compress some assets [PR#88](https://github.com/litebird/litebird_sim/pull/88)
 
 - Improve the `Observation` API. Deprecate the pointing-related methods (moved to `scanning`), quantities are local by default [PR#84](https://github.com/litebird/litebird_sim/pull/84)

--- a/poetry.lock
+++ b/poetry.lock
@@ -266,7 +266,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "ducc0"
-version = "0.7.0"
+version = "0.8.0"
 description = "Distinctly useful code collection"
 category = "main"
 optional = false
@@ -1593,7 +1593,7 @@ mpi = ["mpi4py"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "0e64bc460c448f8a18fbcd2f63a48d0c37b4a43c5b0507461bf9b39b846020bd"
+content-hash = "f97050dffe628e52d9441f207ff077b122d66fe9b166e8df649d323818ac635e"
 
 [metadata.files]
 alabaster = [
@@ -1762,7 +1762,7 @@ docutils = [
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
 ]
 ducc0 = [
-    {file = "ducc0-0.7.0.tar.gz", hash = "sha256:3b1257417694c5f4e4211264b7110f7f6c704d5861aa80d24e6b1bf5dc18ea99"},
+    {file = "ducc0-0.8.0.tar.gz", hash = "sha256:b69beb38408dd8a350753271bd49ce03e60eb0c6ea255d6681e6b058c1c75b48"},
 ]
 entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ rich = "^6.2.0"
 sphinxcontrib-contentui = "^0.2.5"
 
 dataclasses = {version = "^0.7", python = ">=3.6, <3.7"}
-ducc0 = "^0.7.0"
+ducc0 = "^0.8.0"
 pysm3 = "^3.3.0"
 
 [tool.poetry.extras]


### PR DESCRIPTION
This PR updates ducc0 to version 0.8.0, which enables the use of the `DUCC0_OPTIMIZATION` variable. This should permit to overcome the problems described in issue #91.
