### PR TITLE
Clarify the relationship btw IMO and litebird_sim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Version 0.2.0
 
+- Clarify how the IMO is used by `litebird_sim` [PR#94](https://github.com/litebird/litebird_sim/pull/94)
+
 - Make tests run faster by using ducc0 0.8.0 [PR#92](https://github.com/litebird/litebird_sim/pull/92)
 
 - Misc minor changes: gitignore .DS_Store; losslessly compress some assets [PR#88](https://github.com/litebird/litebird_sim/pull/88)

--- a/docs/source/imo.rst
+++ b/docs/source/imo.rst
@@ -9,6 +9,20 @@ the beams, etc. This kind of information is stored in an «instrument
 model database», called IMO, and the LiteBIRD Simulation Framework
 provides a few facilities to access it.
 
+.. note::
+
+   The type of information stored in the LiteBIRD Instrument Model
+   Database is extremely diverse: it goes from CAD/optical/thermal
+   models to high-level parameters representing some general
+   characteristics of the instrument.
+
+   The LiteBIRD Simulation Framework enables to access any information
+   stored in the IMO, but it only provides full support for those
+   parameters that are actually used by the framework itself. (As an
+   example, you can use this interface to download a CAD file, but the
+   framework does not implement any facility to render/analyze the
+   file.)
+
 Let's start from a simple example, which will guide us in the
 following paragraphs::
 
@@ -46,7 +60,12 @@ and disadvantages:
 
 1. Having the IMO saved in a local file (like in the example above) is
    the fastest way to access its contents. However, it might not
-   contain the latest version of the data you're looking for.
+   contain the latest version of the data you're looking for. Note
+   that the framework does not require that a *full* database be
+   available, as only the data that are actually needed in a
+   simulation are retrieved: for this reason, you might opt to
+   download a reduced version of the IMO containing only the
+   high-level parameters used by the Simulation Framework.
 
 2. Using a remote IMO through an Internet connection ensures that you
    have access to the most updated version of the instrument; however,


### PR DESCRIPTION
Following a request by the IMO team, this PR clarifies that the Simulation Framework only provides support for those high-level parameters that are actually used by the framework itself.
