### PR TITLE
Write simulation in tmp directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Version 0.2.0
 
+- Ensure that tests do not write within the source-code directory [PR#97](https://github.com/litebird/litebird_sim/pull/97)
+
 - Clarify how the IMO is used by `litebird_sim` [PR#94](https://github.com/litebird/litebird_sim/pull/94)
 
 - Make tests run faster by using ducc0 0.8.0 [PR#92](https://github.com/litebird/litebird_sim/pull/92)

--- a/test/test_mapping.py
+++ b/test/test_mapping.py
@@ -24,7 +24,7 @@ def test_accumulate_map_and_info():
 
     # Create the TOD and the target result
     tod = pointing_matrix.reshape(n_samples, -1).dot(res_map.reshape(-1))
-    res_info = np.einsum('tpi,tpj->pij', pointing_matrix, pointing_matrix)
+    res_info = np.einsum("tpi,tpj->pij", pointing_matrix, pointing_matrix)
     res_info[:, 1, 0] = np.bincount(pix, tod)
     res_info[:, 2, 0] = np.bincount(pix, tod * np.cos(2 * psi))
     res_info[:, 2, 1] = np.bincount(pix, tod * np.sin(2 * psi))
@@ -38,13 +38,13 @@ def test_accumulate_map_and_info():
     assert np.allclose(np.linalg.solve(info, rhs), res_map)
 
 
-def test_make_bin_map_api_simulation():
+def test_make_bin_map_api_simulation(tmp_path):
     # We should add a more meaningful observation:
     # Currently this test just shows the interface
     sim = lbs.Simulation(
-        base_path="./tut04",
-        start_time=0,
-        duration_s=86400.,
+        base_path=tmp_path / "tut04",
+        start_time=0.0,
+        duration_s=86400.0,
     )
 
     sim.generate_spin2ecl_quaternions(
@@ -56,8 +56,7 @@ def test_make_bin_map_api_simulation():
             precession_rate_hz=1 / (4 * u.day).to("s").value,
         )
     )
-    instr = lbs.InstrumentInfo(name="core",
-                               spin_boresight_angle_rad=np.radians(65))
+    instr = lbs.InstrumentInfo(name="core", spin_boresight_angle_rad=np.radians(65))
     det = lbs.DetectorInfo(name="foo", sampling_rate_hz=10)
     obss = sim.create_observations(detectors=[det])
     pointings = lbs.get_pointings(
@@ -107,9 +106,9 @@ def test_make_bin_map_basic_mpi():
         obs.psi = psi.reshape(2, 5)
 
     obs.set_n_blocks(n_blocks_time=obs.comm.size, n_blocks_det=1)
-    res = mapping.make_bin_map([obs], 1)[:len(res_map)]
+    res = mapping.make_bin_map([obs], 1)[: len(res_map)]
     assert np.allclose(res, res_map)
 
     obs.set_n_blocks(n_blocks_time=1, n_blocks_det=obs.comm.size)
-    res = mapping.make_bin_map([obs], 1)[:len(res_map)]
+    res = mapping.make_bin_map([obs], 1)[: len(res_map)]
     assert np.allclose(res, res_map)


### PR DESCRIPTION
The test code for the binning map-making tries to create a directory within the source tree (in `litebird_sim/test`). This causes issues with read-only containers; moreover, tests should always write files/folders under a temporary path. This PR fixes the issue.
