### PR TITLE
Module for scanning a map and filling TOD 

### DIFF
--- a/docs/source/sky_maps.rst
+++ b/docs/source/sky_maps.rst
@@ -1,3 +1,5 @@
+.. _Mbs:
+
 Synthetic sky maps
 ==================
 

--- a/docs/source/timeordered.rst
+++ b/docs/source/timeordered.rst
@@ -80,20 +80,20 @@ shows:
    lbs.scan_map_in_observations(obs, pointings, hwp_radpsec, in_map)
    
    for i in range(obs.n_samples):
-       print(f"{obs.tod[0][i]:.5e}")
+       print(f"{obs.tod[0][i]:.5f}")
 
 .. testoutput::
 
-   -3.89414e-07
-   -1.44749e-01
-   -2.61039e-01
-   -3.45981e-01
-   -3.97462e-01
-   -4.14204e-01
-   -3.95788e-01
-   -3.42674e-01
-   -2.56182e-01
-   -1.38462e-01
+   0.00000
+   -0.14475
+   -0.26104
+   -0.34598
+   -0.39746
+   -0.41420
+   -0.39579
+   -0.34267
+   -0.25618
+   -0.13846   
 
 
 The input maps to scan must be included in a dictionary with either the name of

--- a/docs/source/timeordered.rst
+++ b/docs/source/timeordered.rst
@@ -80,7 +80,9 @@ shows:
    lbs.scan_map_in_observations(obs, pointings, hwp_radpsec, in_map)
    
    for i in range(obs.n_samples):
-       print(f"{obs.tod[0][i]:.5f}")
+       # + 0. removes leading minus from negative zero
+       value = np.round(obs.tod[0][i], 5) + 0.
+       print(f"{value:.5f}")
 
 .. testoutput::
 
@@ -93,7 +95,7 @@ shows:
    -0.39579
    -0.34267
    -0.25618
-   -0.13846   
+   -0.13846
 
 
 The input maps to scan must be included in a dictionary with either the name of

--- a/docs/source/timeordered.rst
+++ b/docs/source/timeordered.rst
@@ -29,12 +29,13 @@ shows:
 
    hwp_radpsec = np.pi / 8
    start_time_s = 0
+   time_span_s = 1
 
    nside = 256
    npix = 12 * nside * nside
 
    # Create a simulation
-   sim = lbs.Simulation(base_path='./output', start_time=start_time_s, duration_s=1)
+   sim = lbs.Simulation(base_path='./output', start_time=start_time_s, duration_s=time_span_s)
 
    # Create a detector object
    det = lbs.DetectorInfo(
@@ -48,11 +49,11 @@ shows:
        spin_sun_angle_rad=0.785_398_163_397_448_3,
        precession_rate_hz=8.664_850_513_998_931e-05,
        spin_rate_hz=0.000_833_333_333_333_333_4,
-       start_time=start_time,
+       start_time=start_time_s,
    )
 
    spin2ecliptic_quats = scanning.generate_spin2ecl_quaternions(
-       start_time, time_span_s, delta_time_s=7200
+       start_time_s, time_span_s, delta_time_s=7200
    )
 
    instr = lbs.InstrumentInfo(
@@ -62,7 +63,7 @@ shows:
    )
 
    # Initialize the observation
-   obs = sim.create_observations(detectors=[det])
+   (obs,) = sim.create_observations(detectors=[det])
 
    # Compute the pointing
    pointings = lbs.scanning.get_pointings(

--- a/docs/source/timeordered.rst
+++ b/docs/source/timeordered.rst
@@ -22,28 +22,26 @@ through the :file: `.scan_map.py`. You can fill with signal an existing TOD
 by using the function :func:`.scan_map_in_observations`, as the following example
 shows:
 
- .. testcode::
-   
+.. testcode::
+      
    import litebird_sim as lbs
    import numpy as np
-
+   
    hwp_radpsec = np.pi / 8
    start_time_s = 0
    time_span_s = 1
-
+   
    nside = 256
    npix = 12 * nside * nside
-
+   
    # Create a simulation
-   sim = lbs.Simulation(base_path='./output', start_time=start_time_s, duration_s=time_span_s)
-
+   sim = lbs.Simulation(
+       base_path="./output", start_time=start_time_s, duration_s=time_span_s
+   )
+   
    # Create a detector object
-   det = lbs.DetectorInfo(
-     name="Detector",
-     sampling_rate_hz=10,
-     quat=[0.0, 0.0, 0.0, 1.0],
-   )     
-
+   det = lbs.DetectorInfo(name="Detector", sampling_rate_hz=10, quat=[0.0, 0.0, 0.0, 1.0])
+   
    # Define the scanning strategy
    scanning = lbs.SpinningScanningStrategy(
        spin_sun_angle_rad=0.785_398_163_397_448_3,
@@ -51,20 +49,20 @@ shows:
        spin_rate_hz=0.000_833_333_333_333_333_4,
        start_time=start_time_s,
    )
-
+   
    spin2ecliptic_quats = scanning.generate_spin2ecl_quaternions(
        start_time_s, time_span_s, delta_time_s=7200
    )
-
+   
    instr = lbs.InstrumentInfo(
        boresight_rotangle_rad=0.0,
        spin_boresight_angle_rad=0.872_664_625_997_164_8,
        spin_rotangle_rad=3.141_592_653_589_793,
    )
-
+   
    # Initialize the observation
    (obs,) = sim.create_observations(detectors=[det])
-
+   
    # Compute the pointing
    pointings = lbs.scanning.get_pointings(
        obs,
@@ -72,17 +70,15 @@ shows:
        detector_quats=[det.quat],
        bore2spin_quat=instr.bore2spin_quat,
    )
-
-   # Create a map to scan 
+   
+   # Create a map to scan
    # In a realistic simulation use Mbs
    maps = np.ones((3, npix))
    in_map = {"Detector": maps}
 
    # Here scan the map and fill tod
-   lbs.scan_map_in_observations(
-       obs, pointings, hwp_radpsec, in_map,
-   )
-
+   lbs.scan_map_in_observations(obs, pointings, hwp_radpsec, in_map)
+   
    for i in range(obs.n_samples):
        print(f"{obs.tod[0][i]:.5e}")
 

--- a/litebird_sim/__init__.py
+++ b/litebird_sim/__init__.py
@@ -146,7 +146,7 @@ __all__ = [
     "Simulation",
     # noise.py
     "add_noise",
-    #scan_map.py
+    # scan_map.py
     "scan_map",
     "scan_map_in_observations",
     # dipole.py

--- a/litebird_sim/__init__.py
+++ b/litebird_sim/__init__.py
@@ -59,6 +59,7 @@ from .mapping import make_bin_map
 from .destriper import DestriperParameters, DestriperResult, destripe
 from .simulations import Simulation
 from .noise import add_noise
+from .scan_map import scan_map, scan_map_in_observations
 from .version import __author__, __version__
 
 __all__ = [
@@ -136,4 +137,7 @@ __all__ = [
     "Simulation",
     # noise.py
     "add_noise",
+    #scan_map.py
+    "scan_map",
+    "scan_map_in_observations",
 ]

--- a/litebird_sim/mapping.py
+++ b/litebird_sim/mapping.py
@@ -52,7 +52,7 @@ def make_bin_map(obss, nside):
             shapes
 
             * `tod`: the time-ordered data to be mapped
-            * `pixel`: the index of the pixel observed for each tod sample in a
+            * `pixind`: the index of the pixel observed for each tod sample in a
               HEALpix map at nside `nside`
             * `psi`: the polarization angle (in radians) for each tod sample
 
@@ -69,7 +69,7 @@ def make_bin_map(obss, nside):
     info = np.zeros((n_pix, 3, 3))
 
     for obs in obss:
-        _accumulate_map_and_info(obs.tod, obs.pixel, obs.psi, info)
+        _accumulate_map_and_info(obs.tod, obs.pixind, obs.psi, info)
 
     if all([obs.comm is None for obs in obss]) or not mpi.MPI_ENABLED:
         # Serial call

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -6,14 +6,14 @@ import healpy as hp
 
 from astropy.time import Time
 
-from typing import Union, List
+from typing import Union
 
 from .observations import Observation
 
 
 @njit
 def compute_signal_for_one_sample(T, Q, U, co, si):
-    return 0.5 * (T + co*Q + si*U)
+    return 0.5 * (T + co * Q + si * U)
 
 
 @njit
@@ -58,8 +58,8 @@ def scan_map(
             nside, pointings[detector_idx, :, 0], pointings[detector_idx, :, 1]
         )
         pol_angle_det = (
-            pointings[detector_idx, :, 2] + 
-            2 * (start_time_s + np.arange(n_samples) * delta_time_s) * hwp_radpsec
+            pointings[detector_idx, :, 2]
+            + 2 * (start_time_s + np.arange(n_samples) * delta_time_s) * hwp_radpsec
         )
 
         scan_map_for_one_detector(
@@ -81,7 +81,7 @@ def scan_map_in_observations(
     pointings,
     hwp_radpsec,
     maps: List,
-    fill_psi_and_pix: bool = False,
+    fill_psi_and_pixel_in_obs: bool = False,
 ):
     if isinstance(obs, Observation):
         obs_list = [obs]
@@ -95,15 +95,14 @@ def scan_map_in_observations(
         else:
             input_names = cur_obs.channel
 
-
         if isinstance(obs.start_time, Time):
             start_time_s = (cur_obs.start_time - cur_obs.start_time_global).sec
         else:
             start_time_s = cur_obs.start_time - cur_obs.start_time_global
 
-        if fill_psi_and_pix:
+        if fill_psi_and_pixind_in_obs:
             cur_obs.psi = np.empty_like(cur_obs.tod)
-            cur_obs.pixel = np.empty_like(cur_obs.tod,dtype=np.int)
+            cur_obs.pixind = np.empty_like(cur_obs.tod, dtype=np.int)
 
             scan_map(
                 tod=cur_obs.tod,
@@ -114,7 +113,7 @@ def scan_map_in_observations(
                 start_time_s=start_time_s,
                 delta_time_s=cur_obs.get_delta_time().value,
                 pol_angle=cur_obs.psi,
-                pixel_ind=cur_obs.pixel,
+                pixel_ind=cur_obs.pixind,
             )
         else:
             scan_map(
@@ -126,6 +125,3 @@ def scan_map_in_observations(
                 start_time_s=start_time_s,
                 delta_time_s=cur_obs.get_delta_time().value,
             )            
-
-
-

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -58,7 +58,6 @@ def scan_map(
     and the pixel index `pixel_ind` in arrays of size N.
     """
 
-
     assert tod.shape == pointings.shape[0:2]
 
     for detector_idx in range(tod.shape[0]):

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -70,7 +70,8 @@ def scan_map(
         pol_angle_det = np.mod(
             pointings[detector_idx, :, 2]
             + 2 * (start_time_s + np.arange(n_samples) * delta_time_s) * hwp_radpsec,
-        2*np.pi)
+            2 * np.pi,
+        )
 
         scan_map_for_one_detector(
             tod_det=tod[detector_idx],

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -17,12 +17,7 @@ def compute_signal_for_one_sample(T, Q, U, co, si):
 
 
 @njit
-def scan_map_for_one_detector(
-    tod_det,
-    pixel_ind_det,
-    pol_angle_det,
-    maps,
-):
+def scan_map_for_one_detector(tod_det, pixel_ind_det, pol_angle_det, maps):
 
     for i in range(len(tod_det)):
 
@@ -30,12 +25,12 @@ def scan_map_for_one_detector(
         si = np.sin(2 * pol_angle_det[i])
 
         tod_det[i] += compute_signal_for_one_sample(
-            T=maps[0,pixel_ind_det[i]],
-            Q=maps[1,pixel_ind_det[i]],
-            U=maps[2,pixel_ind_det[i]],
+            T=maps[0, pixel_ind_det[i]],
+            Q=maps[1, pixel_ind_det[i]],
+            U=maps[2, pixel_ind_det[i]],
             co=co,
             si=si,
-            )
+        )
 
 
 def scan_map(
@@ -46,8 +41,8 @@ def scan_map(
     input_names,
     start_time_s,
     delta_time_s,
-    pol_angle : Union[np.ndarray, None] = None,
-    pixel_ind : Union[np.ndarray, None] = None,
+    pol_angle: Union[np.ndarray, None] = None,
+    pixel_ind: Union[np.ndarray, None] = None,
 ):
 
     assert tod.shape == pointings.shape[0:2]
@@ -59,13 +54,17 @@ def scan_map(
 
         n_samples = len(pointings[detector_idx, :, 0])
 
-        pixel_ind_det = hp.ang2pix(nside,pointings[detector_idx, :, 0],pointings[detector_idx, :, 1])
-        pol_angle_det = (pointings[detector_idx,:,2] + 
-            2 * (start_time_s + np.arange(n_samples) * delta_time_s) * hwp_radpsec)
+        pixel_ind_det = hp.ang2pix(
+            nside, pointings[detector_idx, :, 0], pointings[detector_idx, :, 1]
+        )
+        pol_angle_det = (
+            pointings[detector_idx, :, 2] + 
+            2 * (start_time_s + np.arange(n_samples) * delta_time_s) * hwp_radpsec
+        )
 
         scan_map_for_one_detector(
             tod_det=tod[detector_idx],
-            pixel_ind_det = pixel_ind_det,
+            pixel_ind_det=pixel_ind_det,
             pol_angle_det=pol_angle_det,
             maps=maps_det,
         )
@@ -98,9 +97,9 @@ def scan_map_in_observations(
 
 
         if isinstance(obs.start_time, Time):
-            start_time_s = (cur_obs.start_time-cur_obs.start_time_global).sec
+            start_time_s = (cur_obs.start_time - cur_obs.start_time_global).sec
         else:
-            start_time_s = cur_obs.start_time-cur_obs.start_time_global
+            start_time_s = cur_obs.start_time - cur_obs.start_time_global
 
         if fill_psi_and_pix:
             cur_obs.psi = np.empty_like(cur_obs.tod)

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -6,13 +6,14 @@ import healpy as hp
 
 from astropy.time import Time
 
-from typing import Union
+from typing import Union, List
 
 from .observations import Observation
 
 
 @njit
 def compute_signal_for_one_sample(T, Q, U, co, si):
+    """Bolometric equation"""
     return 0.5 * (T + co * Q + si * U)
 
 
@@ -44,6 +45,19 @@ def scan_map(
     pol_angle: Union[np.ndarray, None] = None,
     pixel_ind: Union[np.ndarray, None] = None,
 ):
+    """Scan a map filling time-ordered data
+
+    This function modifies the values in `tod` by adding the contribution of the
+    bolometric equation given a list of TQU maps `maps`. The `pointings` argument
+    must be a N×3 matrix containing the pointing information, where N is the size
+    of the `tod` array. `hwp_radpsec` is the hwp rotation speed in radiants per
+    second.`input_names` is an array containing the keywords that allow to select
+    the proper input in `maps` for each detector in the TOD. `start_time_s` and
+    `delta_time_s` are respectively the start time of the TOD and the time step
+    between two samples. Optionally it can return the polarization angle `pol_angle`
+    and the pixel index `pixel_ind` in arrays of size N.
+    """
+
 
     assert tod.shape == pointings.shape[0:2]
 
@@ -81,8 +95,15 @@ def scan_map_in_observations(
     pointings,
     hwp_radpsec,
     maps: List,
-    fill_psi_and_pixel_in_obs: bool = False,
+    fill_psi_and_pixind_in_obs: bool = False,
 ):
+    """Scan a map filling time-ordered data
+
+    This is a wrapper around the :func:`.scan_map` function that applies to the TOD
+    stored in `obs`, which can either be one :class:`.Observation` instance or a list
+    of observations.
+    """
+
     if isinstance(obs, Observation):
         obs_list = [obs]
     else:
@@ -124,4 +145,4 @@ def scan_map_in_observations(
                 input_names=input_names,
                 start_time_s=start_time_s,
                 delta_time_s=cur_obs.get_delta_time().value,
-            )            
+            )

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -1,0 +1,132 @@
+# -*- encoding: utf-8 -*-
+
+from numba import njit
+import numpy as np
+import healpy as hp
+
+from astropy.time import Time
+
+from typing import Union, List
+
+from .observations import Observation
+
+
+@njit
+def compute_signal_for_one_sample(T, Q, U, co, si):
+    return 0.5 * (T + co*Q + si*U)
+
+
+@njit
+def scan_map_for_one_detector(
+    tod_det,
+    pixel_ind_det,
+    pol_angle_det,
+    maps,
+):
+
+    for i in range(len(tod_det)):
+
+        co = np.cos(2 * pol_angle_det[i])
+        si = np.sin(2 * pol_angle_det[i])
+
+        tod_det[i] += compute_signal_for_one_sample(
+            T=maps[0,pixel_ind_det[i]],
+            Q=maps[1,pixel_ind_det[i]],
+            U=maps[2,pixel_ind_det[i]],
+            co=co,
+            si=si,
+            )
+
+
+def scan_map(
+    tod,
+    pointings,
+    hwp_radpsec,
+    maps,
+    input_names,
+    start_time_s,
+    delta_time_s,
+    pol_angle : Union[np.ndarray, None] = None,
+    pixel_ind : Union[np.ndarray, None] = None,
+):
+
+    assert tod.shape == pointings.shape[0:2]
+
+    for detector_idx in range(tod.shape[0]):
+
+        maps_det = maps[input_names[detector_idx]]
+        nside = hp.npix2nside(maps_det.shape[1])
+
+        n_samples = len(pointings[detector_idx, :, 0])
+
+        pixel_ind_det = hp.ang2pix(nside,pointings[detector_idx, :, 0],pointings[detector_idx, :, 1])
+        pol_angle_det = (pointings[detector_idx,:,2] + 
+            2 * (start_time_s + np.arange(n_samples) * delta_time_s) * hwp_radpsec)
+
+        scan_map_for_one_detector(
+            tod_det=tod[detector_idx],
+            pixel_ind_det = pixel_ind_det,
+            pol_angle_det=pol_angle_det,
+            maps=maps_det,
+        )
+
+        if pixel_ind is not None:
+            pixel_ind[detector_idx] = pixel_ind_det
+
+        if pol_angle is not None:
+            pol_angle[detector_idx] = pol_angle_det
+
+
+def scan_map_in_observations(
+    obs: Union[Observation, List[Observation]],
+    pointings,
+    hwp_radpsec,
+    maps: List,
+    fill_psi_and_pix: bool = False,
+):
+    if isinstance(obs, Observation):
+        obs_list = [obs]
+    else:
+        obs_list = obs
+
+    for cur_obs in obs_list:
+
+        if cur_obs.name[0] in maps:
+            input_names = cur_obs.name
+        else:
+            input_names = cur_obs.channel
+
+
+        if isinstance(obs.start_time, Time):
+            start_time_s = (cur_obs.start_time-cur_obs.start_time_global).sec
+        else:
+            start_time_s = cur_obs.start_time-cur_obs.start_time_global
+
+        if fill_psi_and_pix:
+            cur_obs.psi = np.empty_like(cur_obs.tod)
+            cur_obs.pixel = np.empty_like(cur_obs.tod,dtype=np.int)
+
+            scan_map(
+                tod=cur_obs.tod,
+                pointings=pointings,
+                hwp_radpsec=hwp_radpsec,
+                maps=maps,
+                input_names=input_names,
+                start_time_s=start_time_s,
+                delta_time_s=cur_obs.get_delta_time().value,
+                pol_angle=cur_obs.psi,
+                pixel_ind=cur_obs.pixel,
+            )
+        else:
+            scan_map(
+                tod=cur_obs.tod,
+                pointings=pointings,
+                hwp_radpsec=hwp_radpsec,
+                maps=maps,
+                input_names=input_names,
+                start_time_s=start_time_s,
+                delta_time_s=cur_obs.get_delta_time().value,
+            )            
+
+
+

--- a/test/test_mapping.py
+++ b/test/test_mapping.py
@@ -65,7 +65,7 @@ def test_make_bin_map_api_simulation(tmp_path):
     )
 
     nside = 64
-    obss[0].pixel = hp.ang2pix(nside, pointings[..., 0], pointings[..., 1])
+    obss[0].pixind = hp.ang2pix(nside, pointings[..., 0], pointings[..., 1])
     obss[0].psi = pointings[..., 2]
     mapping.make_bin_map(obss, nside)
 
@@ -100,7 +100,7 @@ def test_make_bin_map_basic_mpi():
     )
     if obs.comm.rank == 0:
         obs.tod[:] = tod.reshape(2, 5)
-        obs.pixel = pix.reshape(2, 5)
+        obs.pixind = pix.reshape(2, 5)
         obs.psi = psi.reshape(2, 5)
 
     obs.set_n_blocks(n_blocks_time=obs.comm.size, n_blocks_det=1)

--- a/test/test_scan_map.py
+++ b/test/test_scan_map.py
@@ -1,0 +1,103 @@
+# -*- encoding: utf-8 -*-
+
+import litebird_sim as lbs
+import numpy as np
+import healpy as hp
+from astropy.time import Time
+
+
+def test_scan_map():
+
+    # The purpose of this test is to simulate the motion of the spacecraft
+    # for one year (see `time_span_s`) and produce *two* timelines: the first
+    # is associated with variables `*_s_o` and refers to the case of a nonzero
+    # velocity of the Solar System, and the second is associated with variables
+    # `*_o` and assumes that the reference frame of the Solar System is the
+    # same as the CMB's (so that there is no dipole).
+
+    start_time = 0
+    time_span_s = 365 * 24 * 3600
+    nside = 16
+    sampling_hz = 1
+    hwp_radpsec = 4.084_070_449_666_731
+
+    npix = hp.nside2npix(nside)
+
+    sim = lbs.Simulation(start_time=start_time, duration_s=time_span_s)
+
+    scanning = lbs.SpinningScanningStrategy(
+        spin_sun_angle_rad=0.785_398_163_397_448_3,
+        precession_rate_hz=8.664_850_513_998_931e-05,
+        spin_rate_hz=0.000_833_333_333_333_333_4,
+        start_time=start_time,
+    )
+
+    spin2ecliptic_quats = scanning.generate_spin2ecl_quaternions(
+        start_time, time_span_s, delta_time_s=7200
+    )
+
+    instr = lbs.InstrumentInfo(
+        boresight_rotangle_rad=0.0,
+        spin_boresight_angle_rad=0.872_664_625_997_164_8,
+        spin_rotangle_rad=3.141_592_653_589_793,
+    )
+
+    detT = lbs.DetectorInfo(
+        name="Boresight_detector_T",
+        sampling_rate_hz=sampling_hz,
+        bandcenter_ghz=100.0,
+        quat=[0.0, 0.0, 0.0, 1.0],
+    )
+
+    detB = lbs.DetectorInfo(
+        name="Boresight_detector_B",
+        sampling_rate_hz=sampling_hz,
+        bandcenter_ghz=100.0,
+        quat=[0.0, 0.0, 1.0 / np.sqrt(2.0), 1.0 / np.sqrt(2.0)],
+    )
+
+    np.random.seed(seed=123456789)
+    maps = np.random.normal(0, 1, (3, npix))
+
+    in_map = {"Boresight_detector_T": maps, "Boresight_detector_B": maps}
+
+    (obs1,) = sim.create_observations(detectors=[detT, detB])
+    (obs2,) = sim.create_observations(detectors=[detT, detB])
+
+    pointings = lbs.scanning.get_pointings(
+        obs1,
+        spin2ecliptic_quats=spin2ecliptic_quats,
+        detector_quats=[detT.quat, detB.quat],
+        bore2spin_quat=instr.bore2spin_quat,
+    )
+
+    lbs.scan_map_in_observations(
+        obs1, pointings, hwp_radpsec, in_map, fill_psi_and_pixind_in_obs=True
+    )
+    out_map1 = lbs.make_bin_map(obs1, nside).T
+
+    times = obs2.get_times()
+    obs2.pixind = np.empty(obs2.tod.shape, dtype=np.int32)
+    obs2.psi = np.empty(obs2.tod.shape)
+    for idet in range(obs2.n_detectors):
+        obs2.pixind[idet, :] = hp.ang2pix(
+            nside, pointings[idet, :, 0], pointings[idet, :, 1]
+        )
+        obs2.psi[idet, :] = np.mod(
+            pointings[idet, :, 2] + 2 * times * hwp_radpsec, 2 * np.pi
+        )
+
+    for idet in range(obs2.n_detectors):
+        obs2.tod[idet, :] = (
+            maps[0, obs2.pixind[idet, :]]
+            + np.cos(2 * obs2.psi[idet, :]) * maps[1, obs2.pixind[idet, :]]
+            + np.sin(2 * obs2.psi[idet, :]) * maps[2, obs2.pixind[idet, :]]
+        )
+
+    out_map2 = lbs.make_bin_map(obs2, nside).T
+
+    np.testing.assert_allclose(
+        out_map1, in_map["Boresight_detector_T"], rtol=1e-6, atol=1e-6
+    )
+
+    np.testing.assert_allclose(out_map1, out_map2, rtol=1e-6, atol=1e-6)

--- a/test/test_scan_map.py
+++ b/test/test_scan_map.py
@@ -9,11 +9,14 @@ from astropy.time import Time
 def test_scan_map():
 
     # The purpose of this test is to simulate the motion of the spacecraft
-    # for one year (see `time_span_s`) and produce *two* timelines: the first
-    # is associated with variables `*_s_o` and refers to the case of a nonzero
-    # velocity of the Solar System, and the second is associated with variables
-    # `*_o` and assumes that the reference frame of the Solar System is the
-    # same as the CMB's (so that there is no dipole).
+    # for one year (see `time_span_s`) and produce *two* maps: the first
+    # is associated with the Observation `obs1` and is built using
+    # `scan_map_in_observations` and `make_bin_map`, the second is associated
+    # the Observation `obs2` and is built directly filling in the test
+    # `tod`, `psi` and `pixind` and then using `make_bin_map`
+    # In the final test `out_map1` is compared with both `out_map2` and the
+    # input map. Both simulations use two orthogonal detectors at the boresight
+    # and input maps generated with `np.random.normal`.
 
     start_time = 0
     time_span_s = 365 * 24 * 3600
@@ -56,7 +59,7 @@ def test_scan_map():
         quat=[0.0, 0.0, 1.0 / np.sqrt(2.0), 1.0 / np.sqrt(2.0)],
     )
 
-    np.random.seed(seed=123456789)
+    np.random.seed(seed=123_456_789)
     maps = np.random.normal(0, 1, (3, npix))
 
     in_map = {"Boresight_detector_T": maps, "Boresight_detector_B": maps}


### PR DESCRIPTION
This PR provides a module able to fill obs.tod given pointing information and input map provided by mbs. It also makes obs compatible with `mapping.py` optionally filling `obs.psi` and `obs.pixind`.
For now, no ecliptic-to-galactic coordinate rotation is implemented internally. So `maps` should be rotated to ecliptic before being fed to the function `scan_map_in_observations`. Probably having an option in mbs for dealing with that is worthed, I'll open an issue for this.
The memory handling can be improved, in particular, if psi and pixind are not filled. 

Some points are still open:
- [ ] Check numba implementation
- [ ] Dealing with e2g rotation (if necessary)
- [ ] Move ang2pix in `scan_map_for_one_detector` to save some memory?
- [ ] Implement test
- [ ] Update documentation