### PR TITLE
Use a cache to store PySM3 data files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,12 +27,15 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      # Unfortunately we must use different keys to store the same data,
+      # otherwise GitHub will complain when multiple jobs are going to
+      # store it
       - name: Cache PySM3 data files
         id: cache-pysm3
         uses: actions/cache@v2
         with:
           path: pysm3-data
-          key: pysm3-data
+          key: pysm3-data-${{ runner.os }}-${{ matrix.python }}-${{ mpi }}
 
       - name: Register PySM3 data path
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,13 @@ jobs:
         env:
           DUCC0_OPTIMIZATION: none
 
+      - name: Enable rich traceback
+        run: |
+          export DESTPATH="$(poetry env info -p)/lib/python${{ matrix.python }}/site-packages/sitecustomize.py"
+          echo -n "from rich.traceback import install\ninstall(show_locals=True)\n" > "$DESTPATH"
+          echo "$DESTPATH"
+          cat "$DESTPATH"
+          
       - name: Tests
         run: bash ./bin/run_tests.sh
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,22 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Cache PySM3 data files
+        id: cache-pysm3
+        uses: actions/cache@v2
+        with:
+          path: pysm3-data
+          key: pysm3-data
+
+      - name: Register PySM3 data path
+        run: |
+          echo "PYSM_LOCAL_DATA=$HOME/pysm3-data" >> $GITHUB_ENV
+
+      - name: Download PySM3 data files
+        if: steps.cache-pysm3.outputs.cache_hit != 'true'
+        run: |
+          git clone https://github.com/galsci/pysm-data "$PYSM_LOCAL_DATA"
+
       - name: Install dependencies
         run: |
           ./bin/install-deps.sh ${{ matrix.mpi }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         id: cache-pysm3
         uses: actions/cache@v2
         with:
-          path: pysm3-data
+          path: ~/pysm3-data
           key: pysm3-data-${{ runner.os }}-${{ matrix.python }}-${{ matrix.mpi }}
 
       - name: Register PySM3 data path

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Enable rich traceback
         run: |
           export DESTPATH="$(poetry env info -p)/lib/python${{ matrix.python }}/site-packages/sitecustomize.py"
-          echo -n "from rich.traceback import install\ninstall(show_locals=True)\n" > "$DESTPATH"
+          echo -e "from rich.traceback import install\ninstall(show_locals=True)\n" > "$DESTPATH"
           echo "$DESTPATH"
           cat "$DESTPATH"
           

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: pysm3-data
-          key: pysm3-data-${{ runner.os }}-${{ matrix.python }}-${{ mpi }}
+          key: pysm3-data-${{ runner.os }}-${{ matrix.python }}-${{ matrix.mpi }}
 
       - name: Register PySM3 data path
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/pysm3-data
-          key: pysm3-data-${{ runner.os }}-${{ matrix.python }}-${{ matrix.mpi }}
+          key: pysm3-data-${{ runner.os }}-${{ matrix.python }}-${{ matrix.mpi }}-${{ secrets.CACHE_VERSION }}
+
 
       - name: Register PySM3 data path
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # HEAD
 
-- Module for simulating hwp systematics (hwp_sys) [PR#117](https://github.com/litebird/litebird_sim/pull/117). The algebra is described in [Giardiello et al.](https://arxiv.org/abs/2106.08031)
-
 - **Breaking change** Drop support for Python 3.6, enable Python 3.9 [#136](https://github.com/litebird/litebird_sim/pull/136)
 
 - **Breaking change** Rename keyword `distribute` to `split_list_over_processes` in `Simulation.create_observations` [#110](https://github.com/litebird/litebird_sim/pull/110)
 
 - **Breaking change** Switch to thermodynamic units in the MBS module [#123](https://github.com/litebird/litebird_sim/pull/123)
+
+- Use a cache to speed up CI builds [PR#147](https://github.com/litebird/litebird_sim/pull/147)
+
+- Module for simulating hwp systematics (hwp_sys) [PR#117](https://github.com/litebird/litebird_sim/pull/117). The algebra is described in [Giardiello et al.](https://arxiv.org/abs/2106.08031)
 
 - Fix Singularity builds [#145](https://github.com/litebird/litebird_sim/issues/145)
 

--- a/litebird_sim/mbs/mbs.py
+++ b/litebird_sim/mbs/mbs.py
@@ -574,7 +574,7 @@ class Mbs:
             nmc_output_directory = output_directory / nmc_str
             if rank == 0:
                 nmc_output_directory.mkdir(parents=True, exist_ok=True)
-            cmb_temp = hp.synfast(cl_cmb, nside, new=True, verbose=False)
+            cmb_temp = hp.synfast(cl_cmb, nside, new=True)
             file_name = f"cmb_{nmc_str}_{file_str}.fits"
             cur_map_path = nmc_output_directory / file_name
             lbs.write_healpix_map_to_file(

--- a/litebird_sim/mbs/mbs.py
+++ b/litebird_sim/mbs/mbs.py
@@ -565,8 +565,6 @@ class Mbs:
         else:
             cmb_map_matrix = None
 
-        os.environ["PYSM_LOCAL_DATA"] = str(output_directory)
-
         for nmc in range(rank * perrank, (rank + 1) * perrank):
             if seed_cmb:
                 np.random.seed(seed_cmb + nmc)
@@ -586,7 +584,7 @@ class Mbs:
             sky = pysm3.Sky(
                 nside=nside,
                 component_objects=[
-                    pysm3.CMBMap(nside, map_IQU=Path(nmc_str) / file_name)
+                    pysm3.CMBMap(nside, map_IQU=(Path(cur_map_path)).absolute())
                 ],
             )
 

--- a/test/test_mbs.py
+++ b/test/test_mbs.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
-import warnings
 
 import litebird_sim as lbs
 import healpy as hp
@@ -48,30 +47,23 @@ PARAMETER_FILE = """
 
 
 def test_mbs():
-    try:
-        # PySM3 produces a lot of warnings when it downloads stuff from Internet
-        warnings.filterwarnings("ignore")
+    with NamedTemporaryFile(mode="w+t", suffix=".toml") as simfile:
+        with TemporaryDirectory() as outdir:
+            simfile.write(PARAMETER_FILE.format(output_directory=outdir))
+        simfile.flush()
 
-        with NamedTemporaryFile(mode="w+t", suffix=".toml") as simfile:
-            with TemporaryDirectory() as outdir:
-                simfile.write(PARAMETER_FILE.format(output_directory=outdir))
-            simfile.flush()
+        sim = lbs.Simulation(base_path=outdir, parameter_file=simfile.name)
 
-            sim = lbs.Simulation(base_path=outdir, parameter_file=simfile.name)
+        myinst = {}
+        myinst["mock"] = {
+            "bandcenter_ghz": 140.0,
+            "bandwidth_ghz": 42.0,
+            "fwhm_arcmin": 30.8,
+            "p_sens_ukarcmin": 6.39,
+        }
+        mbs = lbs.Mbs(sim, sim.parameters["map_based_sims"], instrument=myinst)
+        (maps, saved_maps) = mbs.run_all()
 
-            myinst = {}
-            myinst["mock"] = {
-                "bandcenter_ghz": 140.0,
-                "bandwidth_ghz": 42.0,
-                "fwhm_arcmin": 30.8,
-                "p_sens_ukarcmin": 6.39,
-            }
-            mbs = lbs.Mbs(sim, sim.parameters["map_based_sims"], instrument=myinst)
-            (maps, saved_maps) = mbs.run_all()
-
-            curpath = Path(__file__).parent
-            map_ref = hp.read_map(curpath / "reference_mbs.fits", (0, 1, 2))
-            assert np.allclose(maps["mock"], map_ref, atol=1e-6)
-    finally:
-        # Reset the standard warnings filter
-        warnings.resetwarnings()
+        curpath = Path(__file__).parent
+        map_ref = hp.read_map(curpath / "reference_mbs.fits", (0, 1, 2))
+        assert np.allclose(maps["mock"], map_ref, atol=1e-6)


### PR DESCRIPTION
As it is often the case that PySM3 data files are not available due to network outage, this PR uses https://github.com/actions/cache to cache it. It should be quite efficient, as cache files are compressed using [Zstandard](http://facebook.github.io/zstd/), which in my tests showed very good compression ratios for PySM3 maps.

I use here the trick explained in the [PySM3 User's Manual](https://pysm3.readthedocs.io/en/latest/models.html#input-templates)
