### PR TITLE
Remove deprecation warnings from MBS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 -   Upgrade NumPy from 1.20 to 1.21, Numba from 0.54 to 0.55, Rich from 6.2 to 11.0 [#152](https://github.com/litebird/litebird_sim/pull/152)
 
+-   Remove NumPy's and Healpy's deprecation warnings [#158](https://github.com/litebird/litebird_sim/pull/158)
+
 -   Fix issue [#148](https://github.com/litebird/litebird_sim/issues/148)
 
 -   Use a cache to speed up CI builds [PR#147](https://github.com/litebird/litebird_sim/pull/147)

--- a/litebird_sim/mbs/mbs.py
+++ b/litebird_sim/mbs/mbs.py
@@ -594,7 +594,7 @@ class Mbs:
                     band = instr[chnl].bandwidth_ghz
                     fmin = freq - band / 2.0
                     fmax = freq + band / 2.0
-                    fsteps = np.int(np.ceil(fmax - fmin) + 1)
+                    fsteps = int(np.ceil(fmax - fmin) + 1)
                     bandpass_frequencies = np.linspace(fmin, fmax, fsteps) * u.GHz
                     weights = np.ones(len(bandpass_frequencies))
                     cmb_map = sky.get_emission(bandpass_frequencies, weights)
@@ -609,7 +609,8 @@ class Mbs:
                 fwhm_arcmin = instr[chnl].fwhm_arcmin
                 if smooth:
                     cmb_map_smt = hp.smoothing(
-                        cmb_map, fwhm=np.radians(fwhm_arcmin / 60.0), verbose=False
+                        cmb_map,
+                        fwhm=np.radians(fwhm_arcmin / 60.0),
                     )
                 else:
                     cmb_map_smt = cmb_map
@@ -685,7 +686,7 @@ class Mbs:
                     band = instr[chnl].bandwidth_ghz
                     fmin = freq - band / 2.0
                     fmax = freq + band / 2.0
-                    fsteps = np.int(np.ceil(fmax - fmin) + 1)
+                    fsteps = int(np.ceil(fmax - fmin) + 1)
                     bandpass_frequencies = np.linspace(fmin, fmax, fsteps) * u.GHz
                     weights = np.ones(len(bandpass_frequencies))
                     sky_extrap = sky.get_emission(bandpass_frequencies, weights)
@@ -699,7 +700,8 @@ class Mbs:
                     )
                 if smooth:
                     sky_extrap_smt = hp.smoothing(
-                        sky_extrap, fwhm=np.radians(fwhm_arcmin / 60.0), verbose=False
+                        sky_extrap,
+                        fwhm=np.radians(fwhm_arcmin / 60.0),
                     )
                 else:
                     sky_extrap_smt = sky_extrap
@@ -743,10 +745,11 @@ class Mbs:
                 fg_file_name = f"{chnl}_{cmp}_{file_str}.fits"
                 try:
                     fg_cmp = hp.read_map(
-                        fg_dir_cmp / fg_file_name, (0, 1, 2), verbose=False
+                        fg_dir_cmp / fg_file_name,
+                        (0, 1, 2),
                     )
                 except IndexError:
-                    fg_cmp = hp.read_map(fg_dir_cmp / fg_file_name, verbose=False)
+                    fg_cmp = hp.read_map(fg_dir_cmp / fg_file_name)
                     fg_cmp = np.array(
                         [fg_cmp, np.zeros_like(fg_cmp), np.zeros_like(fg_cmp)]
                     )
@@ -762,7 +765,7 @@ class Mbs:
                     ]
 
                     assert len(cmb_map_path) == 1
-                    cmb = hp.read_map(cmb_map_path[0], (0, 1, 2), verbose=False)
+                    cmb = hp.read_map(cmb_map_path[0], (0, 1, 2))
                     map_tot = fg_tot + cmb
 
                     nmc_str = f"{nmc:04d}"


### PR DESCRIPTION
This PR replaces calls to `np.int` with `int` (deprecated since NumPy 1.20) and the `verbose` flag in calls to `healpy.read_map` (deprecated since Healpy 1.15.0).
