### PR TITLE
Add the ability to specify a branch for Singularity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 -   Upgrade NumPy from 1.20 to 1.21, Numba from 0.54 to 0.55, Rich from 6.2 to 11.0 [#152](https://github.com/litebird/litebird_sim/pull/152)
 
+-   Add the ability to create Singularity container from branches different than `master` [#163](https://github.com/litebird/litebird_sim/pull/163)
+
 -   Make MBS tests more robust against disappearing temporary directories [#162](https://github.com/litebird/litebird_sim/pull/162)
 
 -   Remove NumPy's and Healpy's deprecation warnings [#158](https://github.com/litebird/litebird_sim/pull/158)

--- a/singularity/Singularity.m4
+++ b/singularity/Singularity.m4
@@ -76,7 +76,7 @@ shell. Examples:
         # reason why we run tests here is because AstroPy needs to
         # download a few files, and if we postpone this to %test the
         # filesystem will be read-only).
-        git clone https://github.com/litebird/litebird_sim.git /opt/litebird_sim
+        git clone -b BRANCH https://github.com/litebird/litebird_sim.git /opt/litebird_sim
 
         cd /opt/litebird_sim
 

--- a/singularity/create-singularity-file.sh
+++ b/singularity/create-singularity-file.sh
@@ -2,15 +2,21 @@
 
 readonly ubuntu_version="$1"
 readonly mpi_library="$2"
+if [ "$3" == "" ]; then
+    readonly branch="master"
+else
+    readonly branch="$3"
+fi
 
 if [ "$mpi_library" == "" ]; then
     cat <<EOF
-Usage: $(basename $0) UBUNTU_VERSION MPI_LIBRARY
+Usage: $(basename $0) UBUNTU_VERSION MPI_LIBRARY [BRANCH]
 
 where:
 
   UBUNTU_VERSION is the number of the Ubuntu distribution to use (e.g., 20.04)
   MPI_LIBRARY    is either "openmpi", "mpich", or "none"
+  BRANCH         specifies the branch to clone, or "master" if nothing is provided
 EOF
 
     exit 1
@@ -43,6 +49,7 @@ esac
 
 m4 \
     -DUBUNTU_VERSION="$ubuntu_version" \
+    -DBRANCH="$branch" \
     $mpi_lib $mpi_lib_name $poetry_mpi \
     Singularity.m4 > Singularity
 


### PR DESCRIPTION
This PR introduces an optional parameter for `create-singularity-file.sh` to specify the branch to clone in the container. If not specified, it defaults to `master`, so this is a backward-compatible change.﻿
