### PR TITLE
Let scan_map_in_observations take a list of pointing matrices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
     -   Each `Simulation` object creates random number generators (field `Simulation.random`), in a way that is safe even for MPI applications
 
+-   Make `scan_map_in_observations` and `add_dipole_to_observations` accept list of pointing matrices [#171](https://github.com/litebird/litebird_sim/pull/171)
+
 -   Upgrade NumPy from 1.20 to 1.21, Numba from 0.54 to 0.55, Rich from 6.2 to 11.0 [#152](https://github.com/litebird/litebird_sim/pull/152)
 
 -   Add the ability to create Singularity container from branches different than `master` [#163](https://github.com/litebird/litebird_sim/pull/163)

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -108,7 +108,8 @@ def scan_map_in_observations(
     This is a wrapper around the :func:`.scan_map` function that applies to the TOD
     stored in `obs` and the pointings stored in `pointings`. The two types can either
     bed a :class:`.Observation` instance and a NumPy matrix, or a list
-    of observations and a list of NumPy matrices.
+    of observations and a list of NumPy matrices; in the latter case, they must have
+    the same number of elements.
     """
 
     if isinstance(obs, Observation):
@@ -119,6 +120,14 @@ def scan_map_in_observations(
         obs_list = [obs]
         ptg_list = [pointings]
     else:
+        assert isinstance(pointings, list), (
+            "When you pass a list of observations to scan_map_in_observations, "
+            + "you must do the same for `pointings`"
+        )
+        assert len(obs) == len(pointings), (
+            f"The list of observations has {len(obs)} elements, but "
+            + f"the list of pointings has {len(pointings)} elements"
+        )
         obs_list = obs
         ptg_list = pointings
 

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -6,7 +6,7 @@ import healpy as hp
 
 from astropy.time import Time, TimeDelta
 
-from typing import Union, List
+from typing import Union, List, Dict
 
 from .observations import Observation
 
@@ -37,7 +37,7 @@ def scan_map(
     tod,
     pointings,
     hwp_radpsec,
-    maps,
+    maps: Dict[str, np.ndarray],
     input_names,
     start_time_s,
     delta_time_s,
@@ -97,25 +97,32 @@ def scan_map(
 
 def scan_map_in_observations(
     obs: Union[Observation, List[Observation]],
-    pointings,
+    pointings: Union[np.ndarray, List[np.ndarray]],
     hwp_radpsec,
-    maps: List,
+    maps: Dict[str, np.ndarray],
     input_map_in_galactic: bool = True,
     fill_psi_and_pixind_in_obs: bool = False,
 ):
     """Scan a map filling time-ordered data
 
     This is a wrapper around the :func:`.scan_map` function that applies to the TOD
-    stored in `obs`, which can either be one :class:`.Observation` instance or a list
-    of observations.
+    stored in `obs` and the pointings stored in `pointings`. The two types can either
+    bed a :class:`.Observation` instance and a NumPy matrix, or a list
+    of observations and a list of NumPy matrices.
     """
 
     if isinstance(obs, Observation):
+        assert isinstance(pointings, np.ndarray), (
+            "You must pass a list of observations *and* a list "
+            + "of pointing matrices to scan_map_in_observations"
+        )
         obs_list = [obs]
+        ptg_list = [pointings]
     else:
         obs_list = obs
+        ptg_list = pointings
 
-    for cur_obs in obs_list:
+    for cur_obs, cur_ptg in zip(obs_list, ptg_list):
 
         if cur_obs.name[0] in maps:
             input_names = cur_obs.name
@@ -143,7 +150,7 @@ def scan_map_in_observations(
 
             scan_map(
                 tod=cur_obs.tod,
-                pointings=pointings,
+                pointings=cur_ptg,
                 hwp_radpsec=hwp_radpsec,
                 maps=maps,
                 input_names=input_names,
@@ -156,7 +163,7 @@ def scan_map_in_observations(
         else:
             scan_map(
                 tod=cur_obs.tod,
-                pointings=pointings,
+                pointings=cur_ptg,
                 hwp_radpsec=hwp_radpsec,
                 maps=maps,
                 input_names=input_names,

--- a/litebird_sim/scanning.py
+++ b/litebird_sim/scanning.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 from abc import ABC, abstractmethod
-from typing import Union
+from typing import Union, List
 from uuid import UUID
 
 from astropy.coordinates import ICRS, get_body_barycentric
@@ -918,6 +918,11 @@ def get_pointings(
        direction, you can pass the value ``np.array([[0., 0., 0.,
        1.]])``, which represents the null rotation.
 
+    If you passed an array of :class:`.DetectorInfo` objects to the
+    method :meth:`.Simulation.create_observations` through the
+    parameter `detectors`, you can pass ``None`` and it will use the
+    detector quaternions from the same :class:`.DetectorInfo` objects.
+
     The parameter `bore2spin_quat` is calculated through the class
     :class:`.Instrument`, which has the field ``bore2spin_quat``.
     If all you have is the angle β between the boresight and the
@@ -946,6 +951,14 @@ def get_pointings(
     `pointing_buffer`.
 
     """
+
+    if detector_quats is None:
+        assert "quat" in dir(obs), (
+            "No detector quaternions found, have you passed "
+            + '"detectors=" to Simulation.create_observations?'
+        )
+        detector_quats = obs.quat
+
     det2ecliptic_quats = get_det2ecl_quaternions(
         obs,
         spin2ecliptic_quats,

--- a/test/test_dipole.py
+++ b/test/test_dipole.py
@@ -134,8 +134,8 @@ def test_solar_dipole_fit(tmpdir):
     pos_vel_s_o = lbs.spacecraft_pos_and_vel(orbit_s_o, obs_s_o, delta_time_s=86400.0)
     pos_vel_o = lbs.spacecraft_pos_and_vel(orbit_o, obs_o, delta_time_s=86400.0)
 
-    assert pos_vel_s_o.velocities_km_s.shape == (366, 3)
-    assert pos_vel_o.velocities_km_s.shape == (366, 3)
+    assert pos_vel_s_o.velocities_km_s.shape == (367, 3)
+    assert pos_vel_o.velocities_km_s.shape == (367, 3)
 
     lbs.add_dipole_to_observations(
         obs_s_o, pointings, pos_vel_s_o, dipole_type=lbs.DipoleType.LINEAR
@@ -189,3 +189,61 @@ def test_solar_dipole_fit(tmpdir):
     test.assertAlmostEqual(np.sqrt(np.sum(dip ** 2)) * 1e6, 3362.08, 1)
     test.assertAlmostEqual(l[0], 264.021, 1)
     test.assertAlmostEqual(b[0], 48.253, 1)
+
+
+def test_dipole_list_of_obs(tmp_path):
+    sim = lbs.Simulation(
+        base_path=tmp_path / "simulation_dir",
+        start_time=Time("2020-01-01T00:00:00"),
+        duration_s=100.0,
+    )
+    dets = [
+        lbs.DetectorInfo(name="A", sampling_rate_hz=1),
+        lbs.DetectorInfo(name="B", sampling_rate_hz=1),
+    ]
+
+    sim.create_observations(
+        detectors=dets,
+        num_of_obs_per_detector=2,
+    )
+
+    scanning = lbs.SpinningScanningStrategy(
+        spin_sun_angle_rad=0.785_398_163_397_448_3,
+        precession_rate_hz=8.664_850_513_998_931e-05,
+        spin_rate_hz=0.000_833_333_333_333_333_4,
+        start_time=sim.start_time,
+    )
+
+    spin2ecliptic_quats = scanning.generate_spin2ecl_quaternions(
+        sim.start_time,
+        sim.duration_s,
+        delta_time_s=60,
+    )
+
+    instr = lbs.InstrumentInfo(
+        boresight_rotangle_rad=0.0,
+        spin_boresight_angle_rad=0.872_664_625_997_164_8,
+        spin_rotangle_rad=3.141_592_653_589_793,
+    )
+
+    pointings = []
+    for cur_obs in sim.observations:
+        pointings.append(
+            lbs.scanning.get_pointings(
+                cur_obs,
+                spin2ecliptic_quats=spin2ecliptic_quats,
+                detector_quats=None,
+                bore2spin_quat=instr.bore2spin_quat,
+            )
+        )
+
+    orbit = lbs.SpacecraftOrbit(sim.start_time)
+    pos_vel = lbs.spacecraft_pos_and_vel(orbit, obs=sim.observations, delta_time_s=10.0)
+
+    # Just check that the call works
+    lbs.add_dipole_to_observations(
+        obs=sim.observations,
+        pointings=pointings,
+        pos_and_vel=pos_vel,
+        frequency_ghz=[100.0],
+    )


### PR DESCRIPTION
This PR aims to fix #167

- [X] Let `detector_quats` to be `None` in `scanning.get_pointings`
- [X] Let `scan_map_in_observations` take a list of pointing matrices
- [x] Make `spacecraft_pos_and_vel` able to accept list of observations too
- [x] Let `add_dipole` take a list of pointing matrices

