### PR TITLE
Make Madam work in a MPI environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 -   **Breaking change** Interface of `get_pointings` modified, new function `get_pointings_for_observation` simplifies the pointing generation for a list of observations [#198](https://github.com/litebird/litebird_sim/pull/198)
 
+-   Ensure chronological order for Madam FITS files and make sure that exporting them to Madam works with MPI [#204](https://github.com/litebird/litebird_sim/pull/204) 
+
 -   Properly install Madam template files [#202](https://github.com/litebird/litebird_sim/pull/202)
 
 -   Mark installation errors for rich traceback in CI builds as non fatal [#199](https://github.com/litebird/litebird_sim/pull/199)

--- a/docs/source/mpi.rst
+++ b/docs/source/mpi.rst
@@ -66,6 +66,22 @@ is accepted as well):
   to serial mode.
 
 
+Grasping how MPI is being used
+------------------------------
+
+You will typically use MPI to spread TODs among many MPI processes, so
+that the simulation can span several detectors and a longer time scale.
+Unfortunately, this means that it's often complicated to understand how
+data is being kept in memory.
+
+If you use the :class:`.Simulation` object (and you should, you *really*
+should!), you can call :meth:`.Simulation.describe_mpi_distribution` after
+you have allocated the TODs via :meth:`.Simulation.create_observations`; it
+will return an instance of the class :class:`.MpiDistributionDescr`, which
+can be inspected and printed to the terminal. See Section :ref:`simulations`
+for more information about this.
+
+
 API reference
 -------------
 

--- a/docs/source/observations.rst
+++ b/docs/source/observations.rst
@@ -118,6 +118,15 @@ quantities refer to the same detector. If you need the global detector index,
 you can get it with ``obs.det_idx[0]``, which is created
 at construction time.
 
+To get a better understanding of how observations are being used in a
+MPI simulation, use the method :meth:`.Simulation.describe_mpi_distribution`.
+This method must be called *after* the observations have been allocated using
+:meth:`.Simulation.create_observations`; it will return an instance of the
+class :class:`.MpiDistributionDescr`, which can be inspected to determine
+which detectors and time spans are covered by each observation in all the
+MPI processes that are being used. For more information, refer to the Section
+:ref:`simulations`.
+
 Other notable functionalities
 -----------------------------
 

--- a/docs/source/simulations.rst
+++ b/docs/source/simulations.rst
@@ -324,6 +324,112 @@ However, running the script with the environment variable
   [2020-07-18 06:31:03,224 DEBUG] wrong value of pi!
   $
 
+
+Monitoring MPI processes
+------------------------
+
+When using MPI, the method :meth:`.Simulation.create_observations`
+distributes detectors and time spans over all the available
+MPI processes. The :class:`.Simulation` class provides a method
+that enables the user to inspect how the TOD has been split
+among the many MPI processes: :meth:`.Simulation.describe_mpi_distribution`.
+
+The method must be called at the same time on *all* the MPI
+processess, once you have successfully called
+:meth:`.Simulation.create_observations`::
+
+  import litebird_sim as lbs
+
+  # Be sure to create a `Simulation` object and create
+  # the observations:
+  #
+  #     sim = lbs.Simulation(…)
+  #     sim.create_observations(…)
+
+  # Now ask the framework to report how it's using each MPI process
+  descr = sim.describe_mpi_distribution()
+
+The return type for :meth:`.Simulation.describe_mpi_distribution`
+is :class:`.MpiDistributionDescr`, which can be printed on the
+spot using ``print(descr)``. The result looks like the following
+example:
+
+.. code-block:: text
+
+    # MPI rank #1
+
+    ## Observation #0
+    - Start time: 0.0
+    - Duration: 21600.0 s
+    - 1 detector(s) (0A)
+    - TOD shape: 1×216000
+    - TOD dtype: float64
+
+    ## Observation #1
+    - Start time: 43200.0
+    - Duration: 21600.0 s
+    - 1 detector(s) (0A)
+    - TOD shape: 1×216000
+    - TOD dtype: float64
+
+    # MPI rank #2
+
+    ## Observation #0
+    - Start time: 21600.0
+    - Duration: 21600.0 s
+    - 1 detector(s) (0A)
+    - TOD shape: 1×216000
+    - TOD dtype: float64
+
+    ## Observation #1
+    - Start time: 64800.0
+    - Duration: 21600.0 s
+    - 1 detector(s) (0A)
+    - TOD shape: 1×216000
+    - TOD dtype: float64
+
+    # MPI rank #3
+
+    ## Observation #0
+    - Start time: 0.0
+    - Duration: 21600.0 s
+    - 1 detector(s) (0B)
+    - TOD shape: 1×216000
+    - TOD dtype: float64
+
+    ## Observation #1
+    - Start time: 43200.0
+    - Duration: 21600.0 s
+    - 1 detector(s) (0B)
+    - TOD shape: 1×216000
+    - TOD dtype: float64
+
+    # MPI rank #4
+
+    ## Observation #0
+    - Start time: 21600.0
+    - Duration: 21600.0 s
+    - 1 detector(s) (0B)
+    - TOD shape: 1×216000
+    - TOD dtype: float64
+
+    ## Observation #1
+    - Start time: 64800.0
+    - Duration: 21600.0 s
+    - 1 detector(s) (0B)
+    - TOD shape: 1×216000
+    - TOD dtype: float64
+
+The class :class:`.MpiDistributionDescr` contains a list
+of :class:`.MpiProcessDescr`, which describe the «contents»
+of each MPI process. The most important field in each
+:class:`.MpiProcessDescr` instance is `observations`, which
+is a list of :class:`.MpiObservationDescr` objects: it
+contains the size of the TOD array, the names of the detectors,
+and other useful information. Refer to the documentation of
+each class to know what is inside.
+
+
 API reference
 -------------
 

--- a/litebird_sim/__init__.py
+++ b/litebird_sim/__init__.py
@@ -73,7 +73,12 @@ from .scanning import (
 )
 from .mapping import DestriperParameters, DestriperResult, make_bin_map
 from .destriper import destripe
-from .simulations import Simulation
+from .simulations import (
+    Simulation,
+    MpiObservationDescr,
+    MpiProcessDescr,
+    MpiDistributionDescr,
+)
 from .noise import (
     add_white_noise,
     add_one_over_f_noise,
@@ -188,6 +193,9 @@ __all__ = [
     "destripe",
     # simulations.py
     "Simulation",
+    "MpiObservationDescr",
+    "MpiProcessDescr",
+    "MpiDistributionDescr",
     # noise.py
     "add_white_noise",
     "add_one_over_f_noise",

--- a/litebird_sim/madam.py
+++ b/litebird_sim/madam.py
@@ -293,7 +293,7 @@ def save_simulation_for_madam(
             if first_det_name in x.det_names
         ]
     )
-    if sim.mpi_comm:
+    if sim.mpi_comm and litebird_sim.MPI_ENABLED:
         number_of_files = litebird_sim.MPI_COMM_WORLD.allreduce(number_of_files)
         pointing_files = _combine_file_dictionaries(
             litebird_sim.MPI_COMM_WORLD.allgather(pointing_files),

--- a/litebird_sim/madam.py
+++ b/litebird_sim/madam.py
@@ -2,13 +2,15 @@
 
 from datetime import datetime
 from pathlib import Path
-from typing import Union, Optional, List
+from typing import Union, Optional, List, Dict, Any
 
 from astropy.io import fits
 import jinja2
 
+import litebird_sim
 from . import DetectorInfo
 from .mapping import DestriperParameters
+from .mpi import MPI_COMM_WORLD
 from .observations import Observation
 from .simulations import Simulation
 
@@ -73,14 +75,22 @@ def _save_tod_to_fits(
     )
 
 
+def _combine_file_dictionaries(file_dictionaries):
+    return sorted(
+        [item for sublist in file_dictionaries for item in sublist],
+        key=lambda x: x["file_name"],
+    )
+
+
 def save_simulation_for_madam(
     sim: Simulation,
-    detectors: List[DetectorInfo],
     params: DestriperParameters,
+    detectors: Optional[List[DetectorInfo]] = None,
     use_gzip: bool = False,
     output_path: Optional[Union[str, Path]] = None,
     absolute_paths: bool = True,
-):
+    madam_subfolder_name: str = "madam",
+) -> Optional[Dict[str, Any]]:
     """
     Save the TODs and pointings of a simulation to files suitable to be read by Madam
 
@@ -88,31 +98,72 @@ def save_simulation_for_madam(
     them to the directory specified by `output_path` (the default is to save them
     in a sub-folder of the output path of the simulation). The parameter `detector`
     must be a list of :class:`.DetectorInfo` objects, and it specifies which detectors
-    will be saved to disk. The variable `params` specifies how Madam should produce
-    the maps; see the documentation for :class:`.DestriperParameters` for more
-    information.
+    will be saved to disk; if it is ``None``, all the detectors in the simulation will
+    be considered. The variable `params` specifies how Madam should produce the maps;
+    see the documentation for :class:`.DestriperParameters` for more information.
 
     If `use_gzip` is true, the TOD and pointing files will be compressed using Gzip
     (the default is false, as this might slow down I/O). If `absolute_paths` is ``True``
     (the default), the parameter and simulation files produced by this routine will
     be *absolute*; set it to `False` if you plan to move the FITS files to some other
     directory or computer before running Madam.
+
+    The parameter `madam_subfolder_name` is the name of the directory within the
+    output folder of the simulation that will contain the Madam parameter files.
+
+    If you are using MPI, call this function on *all* the MPI processes, not just on
+    the one with rank #0.
+
+    The return value is either a dictionary containing all the parameters used to
+    fill Madam files (the parameter file and the simulation file) or ``None``;
+    the dictionary is only returned for the MPI process with rank #0.
     """
-    sim_template, par_template = _read_templates()
 
-    if not output_path:
-        madam_base_path = sim.base_path / "madam"
+    # All the code revolves around the result of the first call to
+    # Simulation.describe_mpi_distribution(), which returns a
+    # description of the way observations are spread among the
+    # MPI processes. This is *vital* to build correct FITS files
+    # for Madam, as the TODs of each detectors must be saved in
+    # files whose names contain an increasing integer index. We
+    # use `distribution` to properly compute these indexes.
+    #
+    # Consider this (willingly convoluted) distribution of detectors
+    # among observations, indicated with [], and MPI processes:
+    #
+    # MPI#1:   obs1:[A]  obs2:[B]  obs3:[A]  obs4:[A]
+    # MPI#2:   obs1:[C]  obs2:[D]  obs3:[E]  obs4:[F]
+    # MPI#3:   obs1:[A]  obs2:[D]  obs3:[C]  obs4:[F]
+    # MPI#4:   obs1:[D]  obs2:[D]  obs3:[F]  obs4:[F]
+    #
+    # Forget the fact that the number of observations for detector A
+    # is greater than for detector B (something that Madam would
+    # reject), and concentrate on the task required to process MPI#4:
+    # it only contains observations for detectors D and F, and it must
+    # save them so that they do not interfere with files saved by other
+    # MPI processes for the same detectors. Thus, it must know that obs2
+    # in MPI#2 (index #0) and obs2 in MPI#3 (index #1) refer to detector
+    # D, and thus the FITS files that MPI#4 will save for D will have
+    # their index starting from 2.
+
+    distribution = sim.describe_mpi_distribution()
+    assert distribution is not None
+
+    if detectors is not None:
+        # Compute the intersection between the list of detectors passed as an argument
+        # and the detectors that have been actually used in the simulation
+        matching_names = list(
+            set((x.name for x in detectors))
+            & set((x.name for x in distribution.detectors))
+        )
+
+        # Filter out the mismatched detectors
+        detectors = [x for x in detectors if x.name in matching_names]
     else:
-        if Path(output_path).is_absolute():
-            madam_base_path = Path(output_path)
-        else:
-            madam_base_path = sim.base_path / output_path
+        detectors = distribution.detectors
 
-    if absolute_paths:
-        madam_base_path = madam_base_path.absolute()
+    rank = litebird_sim.MPI_COMM_WORLD.rank
 
     madam_detectors = []
-    det_to_index = {}
     for idx, det in enumerate(detectors):
         det_id = idx + 1
         madam_detectors.append(
@@ -126,116 +177,164 @@ def save_simulation_for_madam(
             }
         )
 
-        det_to_index[det.name] = det_id
+    if not output_path:
+        madam_base_path = sim.base_path / madam_subfolder_name
+    else:
+        if Path(output_path).is_absolute():
+            madam_base_path = Path(output_path)
+        else:
+            madam_base_path = sim.base_path / output_path
+
+    if absolute_paths:
+        madam_base_path = madam_base_path.absolute()
+
+    if rank == 0:
+        sim_template, par_template = _read_templates()
+
+        simulation_file_path = madam_base_path / "madam.sim"
+        parameter_file_path = madam_base_path / "madam.par"
+
+        ensure_parent_dir_exists(simulation_file_path)
+        ensure_parent_dir_exists(parameter_file_path)
+
+        madam_maps_path = madam_base_path / "maps"
+        madam_maps_path.mkdir(parents=True, exist_ok=True)
+    else:
+        sim_template, par_template = None, None
+        simulation_file_path, parameter_file_path = None, None
+        madam_maps_path = None
+
+    # We might assume that our MPI process is described by
+    # distribution.mpi_processes[rank], but here we relax the
+    # requirement that the list be ordered by MPI rank and
+    # look for the match with a linear search
+    this_process_idx = [
+        idx
+        for idx, val in enumerate(distribution.mpi_processes)
+        if val.mpi_rank == rank
+    ]
+    assert (
+        len(this_process_idx) == 1
+    ), "more than one MPI rank matches Simulation.describe_mpi_distribution()"
+    this_process_idx = this_process_idx[0]
 
     pointing_files = []
     tod_files = []
-    num_of_files_per_detector = {}
 
-    for obs in sim.observations:
-        for det_idx, det_name in enumerate(obs.name):
-            file_idx = num_of_files_per_detector.get("det_name", 0)
-            pointing_file_name = f"pnt_{det_name}_{file_idx:05d}.fits"
+    det_start_idx = {}  # type: Dict[str, idx]
+    # Count how many observations in the MPI processes with rank smaller than ours
+    # refer to the current detector: this is used to determine the index of each
+    # FITS file
+    for cur_mpi_proc in distribution.mpi_processes[0:this_process_idx]:
+        for cur_obs in cur_mpi_proc.observations:
+            for cur_det_name in cur_obs.det_names:
+                det_start_idx[cur_det_name] = det_start_idx.get(cur_det_name, 0) + 1
+
+    # Files per detector that have been written *by this MPI process*
+    num_of_files_per_detector = {}  # type: Dict[str, int]
+
+    for cur_obs in sim.observations:
+        # Note that "detectors" is the *global* list of detectors shared among all the
+        # MPI processes
+        for cur_global_det_idx, cur_detector in enumerate(detectors):
+            cur_det_name = cur_detector.name
+            if cur_det_name not in cur_obs.name:
+                continue
+
+            # This is the index of the detector *within the current observation*.
+            # It's used to pick the right column in the pointing/tod matrices
+            cur_local_det_idx = list(cur_obs.name).index(cur_det_name)
+
+            local_det_file_index = num_of_files_per_detector.get(cur_det_name, 0)
+            file_idx = det_start_idx.get(cur_det_name, 0) + local_det_file_index
+            pointing_file_name = f"pnt_{cur_det_name}_{file_idx:05d}.fits"
             if use_gzip:
                 pointing_file_name = pointing_file_name + ".gz"
             pointing_file_name = madam_base_path / pointing_file_name
 
             _save_pointings_to_fits(
-                obs=obs, det_idx=det_idx, file_name=pointing_file_name
+                obs=cur_obs, det_idx=cur_local_det_idx, file_name=pointing_file_name
             )
 
             pointing_files.append(
                 {
                     "file_name": pointing_file_name,
-                    "det_name": det_name,
-                    "det_id": det_to_index[det_name],
+                    "det_name": cur_det_name,
+                    "det_id": cur_global_det_idx,
                 }
             )
 
-            tod_file_name = f"tod_{det_name}_{file_idx:05d}.fits"
+            tod_file_name = f"tod_{cur_det_name}_{file_idx:05d}.fits"
             if use_gzip:
                 tod_file_name = tod_file_name + ".gz"
             tod_file_name = madam_base_path / tod_file_name
 
-            _save_tod_to_fits(obs=obs, det_idx=det_idx, file_name=tod_file_name)
+            _save_tod_to_fits(
+                obs=cur_obs, det_idx=cur_local_det_idx, file_name=tod_file_name
+            )
 
             tod_files.append(
                 {
                     "file_name": tod_file_name,
-                    "det_name": det_name,
-                    "det_id": det_to_index[det_name],
+                    "det_name": cur_det_name,
+                    "det_id": cur_global_det_idx,
                 }
             )
 
-            num_of_files_per_detector[det_name] = file_idx + 1
+            num_of_files_per_detector[cur_det_name] = local_det_file_index + 1
 
-    # Check that all the detectors have the same sampling rate
-    sampling_rate_hz = detectors[0].sampling_rate_hz
-    for i in range(1, len(detectors)):
-        if detectors[i].sampling_rate_hz != sampling_rate_hz:
-            raise ValueError(
-                (
-                    "All the detectors must have the same sampling frequency "
-                    "({val1} Hz ≠ {val2} Hz for '{name1}' and '{name2}')"
-                ).format(
-                    val1=detectors[i].sampling_rate_hz,
-                    val2=sampling_rate_hz,
-                    name1=detectors[i].name,
-                    name2=detectors[0].name,
-                )
-            )
+    # To check how many files per detector have been created by any MPI process, just
+    # count the ones that refer to the *first* detector
+    first_det_name = detectors[0].name
+    number_of_files = sum(
+        [
+            1
+            for x in distribution.mpi_processes[this_process_idx].observations
+            if first_det_name in x.det_names
+        ]
+    )
+    if sim.mpi_comm:
+        number_of_files = litebird_sim.MPI_COMM_WORLD.allreduce(number_of_files)
+        pointing_files = _combine_file_dictionaries(
+            litebird_sim.MPI_COMM_WORLD.allgather(pointing_files),
+        )
+        tod_files = _combine_file_dictionaries(
+            litebird_sim.MPI_COMM_WORLD.allgather(tod_files)
+        )
 
-    # Check that the number of files per detector is always the same
-    number_of_files = num_of_files_per_detector[detectors[0].name]
-    for det in detectors:
-        if num_of_files_per_detector[det.name] != number_of_files:
-            raise ValueError(
-                (
-                    "All the detectors must be split in the same number of "
-                    "observations ({num1} ≠ {num2} for '{name1}' and '{name2}')"
-                ).format(
-                    num1=num_of_files_per_detector[det.name],
-                    num2=number_of_files,
-                    name1=det.name,
-                    name2=detectors[0].name,
-                )
-            )
+    if rank == 0:
+        sampling_rate_hz = detectors[0].sampling_rate_hz
 
-    simulation_file_path = madam_base_path / "madam.sim"
-    parameter_file_path = madam_base_path / "madam.par"
+        parameters = {
+            "current_date": datetime.now(),
+            "detectors": madam_detectors,
+            "pointing_files": pointing_files,
+            "tod_files": tod_files,
+            "sampling_rate_hz": sampling_rate_hz,
+            "number_of_files": number_of_files,
+            "pointings_path": "",
+            "tod_path": "",
+            "nside": params.nside,
+            "simulation_file_name": str(simulation_file_path),
+            "parameter_file_name": str(parameter_file_path),
+            "samples_per_baseline": int(params.baseline_length_s * sampling_rate_hz),
+            "madam_output_path": madam_maps_path,
+            "madam_destriped_file_name": "destriped.fits"
+            if params.return_destriped_map
+            else "",
+            "madam_baseline_file_name": "baselines.fits",
+            "madam_binned_file_name": "binned.fits" if params.return_binned_map else "",
+            "madam_cov_file_name": "cov.fits" if params.return_npp else "",
+            "madam_hit_file_name": "hits.fits" if params.return_hit_map else "",
+            "iter_max": params.iter_max,
+        }
 
-    ensure_parent_dir_exists(simulation_file_path)
-    ensure_parent_dir_exists(parameter_file_path)
+        with simulation_file_path.open("wt") as outf:
+            outf.write(sim_template.render(**parameters))
 
-    madam_maps_path = madam_base_path / "maps"
-    madam_maps_path.mkdir(parents=True, exist_ok=True)
+        with parameter_file_path.open("wt") as outf:
+            outf.write(par_template.render(**parameters))
 
-    parameters = {
-        "current_date": datetime.now(),
-        "detectors": madam_detectors,
-        "pointing_files": pointing_files,
-        "tod_files": tod_files,
-        "sampling_rate_hz": sampling_rate_hz,
-        "number_of_files": number_of_files,
-        "pointings_path": "",
-        "tod_path": "",
-        "nside": params.nside,
-        "simulation_file_name": str(simulation_file_path),
-        "parameter_file_name": str(parameter_file_path),
-        "samples_per_baseline": int(params.baseline_length_s * sampling_rate_hz),
-        "madam_output_path": madam_maps_path,
-        "madam_destriped_file_name": "destriped.fits"
-        if params.return_destriped_map
-        else "",
-        "madam_baseline_file_name": "baselines.fits",
-        "madam_binned_file_name": "binned.fits" if params.return_binned_map else "",
-        "madam_cov_file_name": "cov.fits" if params.return_npp else "",
-        "madam_hit_file_name": "hits.fits" if params.return_hit_map else "",
-        "iter_max": params.iter_max,
-    }
-
-    with simulation_file_path.open("wt") as outf:
-        outf.write(sim_template.render(**parameters))
-
-    with parameter_file_path.open("wt") as outf:
-        outf.write(par_template.render(**parameters))
+        return parameters
+    else:
+        return None

--- a/litebird_sim/madam.py
+++ b/litebird_sim/madam.py
@@ -68,6 +68,10 @@ def _save_tod_to_fits(
     table = fits.BinTableHDU.from_columns([col])
 
     table.header["DET_NAME"] = obs.name[det_idx]
+    table.header["DET_IDX"] = det_idx
+    table.header["TIME0"] = str(obs.start_time)
+    table.header["MPIRANK"] = litebird_sim.MPI_COMM_WORLD.rank
+    table.header["MPISIZE"] = litebird_sim.MPI_COMM_WORLD.size
 
     table.writeto(
         str(file_name),

--- a/litebird_sim/madam.py
+++ b/litebird_sim/madam.py
@@ -69,7 +69,9 @@ def _save_tod_to_fits(
 
     table.header["DET_NAME"] = obs.name[det_idx]
     table.header["DET_IDX"] = det_idx
-    table.header["TIME0"] = str(obs.start_time)
+    table.header["TIME0"] = (
+        obs.start_time if isinstance(obs.start_time, float) else str(obs.start_time)
+    )
     table.header["MPIRANK"] = litebird_sim.MPI_COMM_WORLD.rank
     table.header["MPISIZE"] = litebird_sim.MPI_COMM_WORLD.size
 

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -119,7 +119,7 @@ class MpiObservationDescr:
     """
 
     det_names: List[str]
-    tod_shape: Optional[Tuple[int]]
+    tod_shape: Optional[Tuple[int, int]]
     tod_dtype: Optional[str]
     start_time: Union[float, astropy.time.Time]
     duration_s: float

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -883,7 +883,7 @@ class Simulation:
 
         num_of_observations = len(self.observations)
 
-        if self.mpi_comm:
+        if self.mpi_comm and litebird_sim.MPI_ENABLED:
             observation_descr_all = litebird_sim.MPI_COMM_WORLD.allgather(
                 observation_descr
             )

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -2,15 +2,16 @@
 
 import codecs
 from collections import namedtuple
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from datetime import datetime
 import logging as log
 import os
 import subprocess
-from typing import List, Tuple, Union, Dict, Any
+from typing import List, Tuple, Union, Dict, Any, Optional
 from pathlib import Path
 from shutil import copyfile, copytree, SameFileError
 
+import litebird_sim
 from .detectors import DetectorInfo
 from .distribute import distribute_evenly, distribute_optimally
 from .healpix import write_healpix_map_to_file
@@ -95,6 +96,96 @@ def get_template_file_path(filename: Union[str, Path]) -> Path:
     folder of the ``litebird_sim`` source code.
     """
     return Path(__file__).parent / ".." / "templates" / filename
+
+
+@dataclass
+class MpiObservationDescr:
+    """
+    This class is used within :class:`.MpiProcessDescr`. It describes the
+    kind and size of the data held by a :class:`.Observation` object.
+
+    Its fields are:
+
+    - `det_names` (list of ``str``): names of the detectors handled by
+      this observation
+    - `tod_shape` (tuple of ``int``): shape of the TOD held by the observation
+    - `tod_dtype` (``str``): string representing the NumPy data type of the TOD
+    - `start_time` (either a ``float`` or a ``astropy.time.Time``): start date
+      of the observation
+    - `duration_s` (``float``): duration of the TOD in seconds
+    - `num_of_samples` (``int``): number of samples held by this TOD
+    - `num_of_detectors` (``int``): number of detectors held by this TOD. It's
+      the length of the field `det_names` (see above)
+    """
+
+    det_names: List[str]
+    tod_shape: Optional[Tuple[int]]
+    tod_dtype: Optional[str]
+    start_time: Union[float, astropy.time.Time]
+    duration_s: float
+    num_of_samples: int
+    num_of_detectors: int
+
+
+@dataclass
+class MpiProcessDescr:
+    """
+    Description of the kind of data held by a MPI process
+
+    This class is used within :class:`MpiDistributionDescr`. Its fields are:
+
+    - `mpi_rank`: rank of the MPI process described by this instance
+    - `observations`: list of :class:`.MpiObservationDescr` objects, each
+      describing one observation managed by the MPI process with rank
+      `mpi_rank`.
+
+    """
+
+    mpi_rank: int
+    observations: List[MpiObservationDescr]
+
+
+@dataclass
+class MpiDistributionDescr:
+    """A class that describes how observations are distributed among MPI processes
+
+    The fields defined in this dataclass are the following:
+
+    - `num_of_observations` (int): overall number of observations in *all* the
+      MPI processes
+    - `detectors` (list of :class:`.DetectorInfo` objects): list of *all* the
+      detectors used in the observations
+    - `mpi_processes`: list of :class:`.MpiProcessDesc` instances, describing
+      the kind of data that each MPI process is currently holding
+
+    Use :meth:`.Simulation.describe_mpi_distribution` to get an instance of this
+    object."""
+
+    num_of_observations: int
+    detectors: List[DetectorInfo]
+    mpi_processes: List[MpiProcessDescr]
+
+    def __repr__(self):
+        result = ""
+        for cur_mpi_proc in self.mpi_processes:
+            result += f"# MPI rank #{cur_mpi_proc.mpi_rank + 1}\n\n"
+            for cur_obs_idx, cur_obs in enumerate(cur_mpi_proc.observations):
+                result += """## Observation #{obs_idx}
+- Start time: {start_time}
+- Duration: {duration_s} s
+- {num_of_detectors} detector(s) ({det_names})
+- TOD shape: {tod_shape}
+
+""".format(
+                    obs_idx=cur_obs_idx,
+                    start_time=cur_obs.start_time,
+                    duration_s=cur_obs.duration_s,
+                    num_of_detectors=len(cur_obs.det_names),
+                    det_names=",".join(cur_obs.det_names),
+                    tod_shape="×".join([str(x) for x in cur_obs.tod_shape]),
+                )
+
+        return result
 
 
 class Simulation:
@@ -191,6 +282,7 @@ class Simulation:
         self.start_time = start_time
         self.duration_s = duration_s
 
+        self.detectors = []  # type: List[DetectorInfo]
         self.spin2ecliptic_quats = None
 
         self.description = description
@@ -695,7 +787,7 @@ class Simulation:
 
         duration_s = self.duration_s  # Cache the value to a local variable
         sampfreq_hz = detectors[0].sampling_rate_hz
-        detectors = [asdict(d) for d in detectors]
+        self.detectors = detectors
         num_of_samples = int(sampfreq_hz * duration_s)
         samples_per_obs = distribute_evenly(num_of_samples, num_of_obs_per_detector)
 
@@ -704,7 +796,7 @@ class Simulation:
         for cur_obs_idx in range(num_of_obs_per_detector):
             nsamples = samples_per_obs[cur_obs_idx].num_of_elements
             cur_obs = Observation(
-                detectors=detectors,
+                detectors=[asdict(d) for d in detectors],
                 start_time_global=cur_time,
                 sampling_rate_hz=sampfreq_hz,
                 n_samples_global=nsamples,
@@ -744,6 +836,75 @@ class Simulation:
         self.observations = observations[
             span.start_idx : (span.start_idx + span.num_of_elements)
         ]
+
+    def describe_mpi_distribution(self) -> Optional[MpiDistributionDescr]:
+        """Return a :class:`.MpiDistributionDescr` object describing observations
+
+        This method returns a :class:`.MpiDistributionDescr` that describes the data
+        stored in each MPI process running concurrently. It is a great debugging tool
+        when you are using MPI, and it can be used for tasks where you have to carefully
+        orchestrate they way different MPI processes run together.
+
+        This method should be called by *all* the MPI processes. It can be executed in a
+        serial environment (i.e., without MPI) and will still return meaningful values.
+
+        The typical usage for this method is to call it once you have called
+        :meth:`.Simulation.create_observations` to check that the TODs have been
+        laid in memory in the way you expect::
+
+            sim.create_observations(…)
+            distr = sim.describe_mpi_distribution()
+            if litebird_sim.MPI_COMM_WORLD.rank == 0:
+                print(distr)
+
+        """
+
+        if not self.observations:
+            return None
+
+        observation_descr = []  # type: List[MpiObservationDescr]
+        for obs in self.observations:
+            cur_det_names = list(obs.name)
+
+            observation_descr.append(
+                MpiObservationDescr(
+                    det_names=cur_det_names,
+                    tod_shape=tuple(obs.tod.shape) if "tod" in dir(obs) else None,
+                    tod_dtype=obs.tod.dtype.name if "tod" in dir(obs) else None,
+                    start_time=obs.start_time,
+                    duration_s=obs.n_samples / obs.sampling_rate_hz,
+                    num_of_samples=obs.n_samples,
+                    num_of_detectors=obs.n_detectors,
+                )
+            )
+
+        num_of_observations = len(self.observations)
+
+        if self.mpi_comm:
+            observation_descr_all = litebird_sim.MPI_COMM_WORLD.allgather(
+                observation_descr
+            )
+            num_of_observations_all = litebird_sim.MPI_COMM_WORLD.allgather(
+                num_of_observations
+            )
+        else:
+            observation_descr_all = [observation_descr]
+            num_of_observations_all = [num_of_observations]
+
+        mpi_processes = []  # type: List[MpiProcessDescr]
+        for i in range(litebird_sim.MPI_COMM_WORLD.size):
+            mpi_processes.append(
+                MpiProcessDescr(
+                    mpi_rank=i,
+                    observations=observation_descr_all[i],
+                )
+            )
+
+        return MpiDistributionDescr(
+            num_of_observations=sum(num_of_observations_all),
+            detectors=self.detectors,
+            mpi_processes=mpi_processes,
+        )
 
     def generate_spin2ecl_quaternions(
         self,

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -155,7 +155,7 @@ class MpiDistributionDescr:
       MPI processes
     - `detectors` (list of :class:`.DetectorInfo` objects): list of *all* the
       detectors used in the observations
-    - `mpi_processes`: list of :class:`.MpiProcessDesc` instances, describing
+    - `mpi_processes`: list of :class:`.MpiProcessDescr` instances, describing
       the kind of data that each MPI process is currently holding
 
     Use :meth:`.Simulation.describe_mpi_distribution` to get an instance of this
@@ -175,6 +175,7 @@ class MpiDistributionDescr:
 - Duration: {duration_s} s
 - {num_of_detectors} detector(s) ({det_names})
 - TOD shape: {tod_shape}
+- TOD dtype: {tod_dtype}
 
 """.format(
                     obs_idx=cur_obs_idx,
@@ -183,6 +184,7 @@ class MpiDistributionDescr:
                     num_of_detectors=len(cur_obs.det_names),
                     det_names=",".join(cur_obs.det_names),
                     tod_shape="×".join([str(x) for x in cur_obs.tod_shape]),
+                    tod_dtype=cur_obs.tod_dtype,
                 )
 
         return result

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -845,6 +845,9 @@ class Simulation:
         when you are using MPI, and it can be used for tasks where you have to carefully
         orchestrate they way different MPI processes run together.
 
+        If this method is called before :meth:`.Simulation.create_observations`, it will
+        return ``None``.
+
         This method should be called by *all* the MPI processes. It can be executed in a
         serial environment (i.e., without MPI) and will still return meaningful values.
 

--- a/test/test_madam.py
+++ b/test/test_madam.py
@@ -1,15 +1,28 @@
 # -*- encoding: utf-8 -*-
 
 import numpy as np
-from numpy.random import SeedSequence, MT19937, RandomState
 import astropy.units as u
 
 import litebird_sim as lbs
 
 
-def test_madam(tmp_path):
+def _num_of_obs_per_detector(descr: lbs.MpiDistributionDescr, det_name: str) -> int:
+    return sum(
+        [
+            1
+            for mpi_proc in descr.mpi_processes
+            for obs in mpi_proc.observations
+            if det_name in obs.det_names
+        ]
+    )
+
+
+def run_test_on_madam(tmp_path, n_blocks_det: int, n_blocks_time: int):
     sim = lbs.Simulation(
-        base_path=tmp_path / "destriper_output", start_time=0, duration_s=86400.0
+        base_path=tmp_path / "destriper_output",
+        start_time=0,
+        duration_s=86400.0,
+        mpi_comm=lbs.MPI_COMM_WORLD,
     )
 
     sim.generate_spin2ecl_quaternions(
@@ -28,13 +41,20 @@ def test_madam(tmp_path):
             name="0B", sampling_rate_hz=10, quat=lbs.quat_rotation_z(np.pi / 2)
         ),
     ]
+
     sim.create_observations(
         detectors=detectors,
-        # num_of_obs_per_detector=lbs.MPI_COMM_WORLD.size,
         dtype_tod=np.float64,
-        n_blocks_time=lbs.MPI_COMM_WORLD.size,
         split_list_over_processes=False,
+        num_of_obs_per_detector=2,
+        n_blocks_det=n_blocks_det,
+        n_blocks_time=n_blocks_time,
     )
+
+    distribution = sim.describe_mpi_distribution()
+    assert distribution is not None
+    if lbs.MPI_COMM_WORLD.rank == 0:
+        print(distribution)
 
     lbs.get_pointings_for_observations(
         sim.observations,
@@ -42,11 +62,8 @@ def test_madam(tmp_path):
         bore2spin_quat=instr.bore2spin_quat,
     )
 
-    # Generate some white noise
-    rs = RandomState(MT19937(SeedSequence(123456789)))
     for cur_obs in sim.observations:
-        cur_obs.tod *= 0.0
-        cur_obs.tod += rs.randn(*cur_obs.tod.shape)
+        cur_obs.tod[:] = float(lbs.MPI_COMM_WORLD.rank)
 
     params = lbs.DestriperParameters(
         nside=16,
@@ -64,4 +81,29 @@ def test_madam(tmp_path):
     # Just check that all the files are saved without errors/exceptions:
     # to verify that the input files are ok, we should download and install
     # Madam…
-    lbs.save_simulation_for_madam(sim, detectors=detectors, params=params)
+    result = lbs.save_simulation_for_madam(sim, detectors=detectors, params=params)
+
+    if lbs.MPI_COMM_WORLD.rank != 0:
+        # The value of "result" is meaningful only for MPI process #0, so there
+        # is no point in continuing
+        return
+
+    assert len(result["detectors"]) == 2
+
+    for det_name in ("0A", "0B"):
+        obs_per_detector = _num_of_obs_per_detector(
+            descr=distribution, det_name=det_name
+        )
+
+        tod_files = [x for x in result["tod_files"] if x["det_name"] == det_name]
+        assert len(tod_files) == obs_per_detector
+
+        pointing_files = [
+            x for x in result["pointing_files"] if x["det_name"] == det_name
+        ]
+        assert len(pointing_files) == obs_per_detector
+
+
+def test_madam(tmp_path):
+    run_test_on_madam(tmp_path, n_blocks_det=lbs.MPI_COMM_WORLD.size, n_blocks_time=1)
+    run_test_on_madam(tmp_path, n_blocks_det=1, n_blocks_time=lbs.MPI_COMM_WORLD.size)


### PR DESCRIPTION
Because of issue #201, Madam files created in a MPI environment do not contain all the TODs. This PR solves the problem by properly running over all the MPI processes.

The PR is quite huge, because the task is complex: Madam requires each detector to have its data in distinct files that must be numbered with an increasing counter. Therefore, to make the code work, this PR implements an algorithm that walks over all the MPI processes and counts how many observations for each of them contribute to each detector.

To make the code clearer to read, and to make `litebird_sim` easier to debug, I have added a new method to `Simulation`: `describe_mpi_distribution()`. Its purpose is to build a «map» of all the observations in every MPI process. This map is defined using the new type `MpiDistributionDescr`, which can be printed to get a visual representation of the way the TOD was split across observations and processes; here is an example:

```
# MPI rank #1

## Observation #0
- Start time: 0.0
- Duration: 21600.0 s
- 1 detector(s) (0A)
- TOD shape: 1×216000

## Observation #1
- Start time: 43200.0
- Duration: 21600.0 s
- 1 detector(s) (0A)
- TOD shape: 1×216000

# MPI rank #2

## Observation #0
- Start time: 21600.0
- Duration: 21600.0 s
- 1 detector(s) (0A)
- TOD shape: 1×216000

## Observation #1
- Start time: 64800.0
- Duration: 21600.0 s
- 1 detector(s) (0A)
- TOD shape: 1×216000

# MPI rank #3

## Observation #0
- Start time: 0.0
- Duration: 21600.0 s
- 1 detector(s) (0B)
- TOD shape: 1×216000

## Observation #1
- Start time: 43200.0
- Duration: 21600.0 s
- 1 detector(s) (0B)
- TOD shape: 1×216000

# MPI rank #4

## Observation #0
- Start time: 21600.0
- Duration: 21600.0 s
- 1 detector(s) (0B)
- TOD shape: 1×216000

## Observation #1
- Start time: 64800.0
- Duration: 21600.0 s
- 1 detector(s) (0B)
- TOD shape: 1×216000
```

Things to do before merging this PR:

- [X] Implement `MpiDistributionDescr` and all ancillary classes
- [X] Implement `describe_mpi_distribution`
- [x] Modify `save_simulation_for_madam` so that it uses `describe_mpi_distribution` to properly walk over all the MPI processes
- [x] Document `describe_mpi_distribution` and `MpiDistributionDescr` in the manual

