### PR TITLE
Improve support for multiple TODs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Improve support for multiple TODs [#205](https://github.com/litebird/litebird_sim/pull/205)
+
 -   Implement a bandpass generator [#160](https://github.com/litebird/litebird_sim/pull/160), [#200](https://github.com/litebird/litebird_sim/pull/200)
 
 # Version 0.8.0

--- a/docs/source/mapmaking.rst
+++ b/docs/source/mapmaking.rst
@@ -190,7 +190,142 @@ The following command will run Madam:
 Of course, in a realistic situation you want to run ``madam`` using MPI,
 so you should call ``mpiexec``, ``mpirun``, or something similar.
 
-   
+
+Creating several maps with Madam
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are cases where you want to create several maps out of
+one simulation. A common case is when you simulate several
+components to be put in the TOD and store them in different
+fields within each :class:`.Observation` object:
+
+.. code-block:: python
+
+  sim.create_observations(params)
+
+  for cur_obs in sim.observations:
+      # We'll include several components in the signal:
+      # CMB, white noise, 1/f noise, and dipole
+      cur_obs.wn_tod = np.zeros_like(cur_obs.tod)
+      cur_obs.oof_tod = np.zeros_like(cur_obs.tod)
+      cur_obs.cmb_tod = np.zeros_like(cur_obs.tod)
+      cur_obs.dip_tod = np.zeros_like(cur_obs.tod)
+
+      # Now fill each of the *_tod fields appropriately
+
+In cases like this, it is often useful to generate several
+sets of maps that include different subsets of the components:
+
+1.  A map including just the CMB and white noise;
+2.  A map including CMB, white noise and 1/f, but not the dipole;
+3.  A map including all the components.
+
+You could of course call :func:`.save_simulation_for_madam` three
+times, but this would be a waste of space because you would end
+up with three identical copies of the FITS file containing the
+pointings, and the last set of FITS files would contain the same
+components that were saved for the first two maps.
+(Remember, :func:`.save_simulation_for_madam` saves both the
+pointings and the TODs!)
+
+A trick to avoid wasting so much space is to save the FITS files
+only once, including *all* the TOD components, and then call
+:func:`.save_simulation_for_madam` again for each other map using
+``save_pointings=False`` and ``save_tods=False``:
+
+.. code-block:: python
+
+  save_files = True
+
+  # Iterate over all the maps we want to produce. For each of
+  # them we specify the name of the subfolder where the Madam
+  # files will be saved and the list of components to include
+  for (subfolder, components_to_bin) in [
+      ("cmb+wn", ["wn_tod", "cmb_tod"]),
+      ("cmb+wn+1f", ["wn_tod", "oof_tod", "cmb_tod"]),
+      ("cmb+wn+1f+dip", ["wn_tod", "oof_tod", "cmb_tod", "dip_tod"]),
+  ]:
+      save_simulation_for_madam(
+          sim=sim,
+          params=params,
+          madam_subfolder_name=subfolder,
+          components=["cmb_tod", "wn_tod", "oof_tod", "dipole_tod"],
+          components_to_bin=components_to_bin,
+          save_pointings=save_files,
+          save_tods=save_files,
+       )
+
+       # Set this to False for all the following iterations (maps)
+       save_files = False
+
+
+It is important that the `components` parameter in the call to
+:func:`.save_simulation_for_madam` list *all* the components, even if they are not going to be used in the first and
+second map. The reason is that this parameter is used by the function to create a «map» of the components as they are
+supposed to be found in the FITS files; for example, the
+``cmb_tod`` field is the *third* in each TOD file, but this
+would not be apparent while producing the first map, where it is the
+*second* in the list of components that must be used. The ``.par``
+file will list the components that need to be actually used to
+create the map, so it will not be confused if the TOD FITS files
+will contain more components than needed. (This is a neat feature
+of Madam.)
+
+Of course, once the three directories ``cmb+wn``, ``cmb+wn+1f``, and
+``cmb+wn+1f+dip`` are created, Madam will run successfully only in
+the first one, ``cmb+wn``. The reason is that only that directory
+includes the pointing and TOD FITS files! But if you are saving data
+on a filesystem that supports `symbolic links
+<https://en.wikipedia.org/wiki/Symbolic_link>`_, you can use them to
+make the files appear in the other directories too. For instance, the
+following commands will create them directly from a Unix shell (Bash,
+Sh, Zsh):
+
+.. code-block:: sh
+
+  ln -srv cmb+wn/*.fits cmb+wn+1f
+  ln -srv cmb+wn/*.fits cmb+wn+1f+dip
+
+(The ``-s`` flag asks to create *soft* links, the ``-r`` flag requires
+paths to be relative, and ``-v`` makes ``ln`` be more verbose.)
+
+If you want a fully authomatic procedure, you can create the symbolic
+links in Python, taking advantage of the fact that
+:func:`.save_simulation_for_madam` returns a dictionary containing the
+information needed to do this programmatically:
+
+.. code-block:: python
+
+   # First map
+   params1 = save_simulation_for_madam(sim, params)
+
+   # Second map
+   params2 = save_simulation_for_madam(
+       sim,
+       params,
+       madam_subfolder_name="madam2",
+       save_pointings=False,
+       save_tods=False,
+   )
+
+   # Caution: you want to do this only within the first MPI process!
+   if litebird_sim.MPI_COMM_WORLD.rank == 0:
+       for source_file, dest_file in zip(
+           params1["tod_files"] + params1["pointing_files"],
+           params2["tod_files"] + params2["pointing_files"],
+       ):
+           # This is a Path object associated with the symlink that we
+           # want to create
+           source_file_path = source_file["file_name"]
+           dest_file_path = dest_file["file_name"]
+
+           dest_file_path.symlink_to(source_file_path)
+
+You can include this snippet of code in the script that calls
+:func:`.save_simulation_for_madam`, so that the procedure will
+be 100% automated.
+
+
 API reference
 -------------
 

--- a/docs/source/mapmaking.rst
+++ b/docs/source/mapmaking.rst
@@ -271,6 +271,58 @@ create the map, so it will not be confused if the TOD FITS files
 will contain more components than needed. (This is a neat feature
 of Madam.)
 
+.. note::
+
+   To understand how this kind of stuff works, it is useful to
+   recap how Madam works, as the possibility to reuse TODs for
+   different maps is linked to the fact that Madam requires
+   *two* files to be run: the *parameter file* and the *simulation
+   file*.
+
+   The *simulation file* represents a «map» of the content of a
+   set of FITS files. No information about the map-making process
+   is included in a simulation file: it just tells how many FITS
+   files should be read and what is inside each of them.
+
+   The *parameter file* is used to tell Madam how you want maps
+   to be created. It's in the parameter file that you can ask
+   Madam to skip parts of the TODs, for example because you do
+   not want to include the dipole in the output map.
+
+   When you call :func:`.save_simulation_for_madam`, the
+   `components` parameter is used to build the *simulation file*:
+   thus, if you plan to build more than one map out of the same
+   set of components, you want to have the very same simulation
+   files, because they «describe» what's in the FITS files. This
+   is the reason why we passed the same value to ``components``
+   every time we called ``save_simulation_for_madam``.
+
+   But when we create the three *parameter files*, each of them
+   differs in the list of components that need to be included.
+   If you inspect the three files ``cmb+wn/madam.par``,
+   ``cmb+wn+1f/madam.par``, and ``cmb+wn+1f+dip/madam.par``, you
+   will see that they only differ for the following lines::
+
+      # cmb+wn/madam.par
+      tod_1 = wn_tod
+      tod_2 = cmb_tod
+
+      # cmb+wn+1f/madam.par
+      tod_1 = wn_tod
+      tod_2 = oof_tod
+      tod_3 = cmb_tod
+
+      # cmb+wn+1f+dip/madam.par
+      tod_1 = wn_tod
+      tod_2 = oof_tod
+      tod_3 = cmb_tod
+      tod_4 = dip_tod
+
+
+   That's it. The lines with ``tod_*`` are enough to
+   do all the magic to build the three maps.
+
+
 Of course, once the three directories ``cmb+wn``, ``cmb+wn+1f``, and
 ``cmb+wn+1f+dip`` are created, Madam will run successfully only in
 the first one, ``cmb+wn``. The reason is that only that directory

--- a/litebird_sim/dipole.py
+++ b/litebird_sim/dipole.py
@@ -288,22 +288,24 @@ def add_dipole_to_observations(
             ptg_list = [point[:, :, 0:2] for point in pointings]
 
     for cur_obs, cur_ptg in zip(obs_list, ptg_list):
+        tod = getattr(cur_obs, component)
+
         # Alas, this allocates memory for the velocity vector! At the moment it is the
         # simplest implementation, but in the future we might want to inline the
         # interpolation code within "add_dipole" to save memory
         velocity = pos_and_vel.compute_velocities(
             time0=cur_obs.start_time,
             delta_time_s=cur_obs.get_delta_time().value,
-            num_of_samples=cur_obs.tod.shape[1],
+            num_of_samples=tod.shape[1],
         )
 
         if frequency_ghz is None:
             frequency_ghz = cur_obs.bandcenter_ghz
         else:
-            frequency_ghz = np.repeat(frequency_ghz, cur_obs.tod.shape[0])
+            frequency_ghz = np.repeat(frequency_ghz, tod.shape[0])
 
         add_dipole(
-            tod=getattr(cur_obs, component),
+            tod=tod,
             pointings=cur_ptg,
             velocity=velocity,
             t_cmb_k=t_cmb_k,

--- a/litebird_sim/dipole.py
+++ b/litebird_sim/dipole.py
@@ -240,12 +240,24 @@ def add_dipole_to_observations(
     frequency_ghz: Union[
         np.ndarray, None
     ] = None,  # e.g. central frequency of channel from
+    component: str = "tod",
 ):
     """Add the CMB dipole to some time-ordered data
 
     This is a wrapper around the :func:`.add_dipole` function that applies to the TOD
     stored in `obs`, which can either be one :class:`.Observation` instance or a list
     of observations.
+
+    By default, the TOD is added to ``Observation.tod``. If you want to add it to some
+    other field of the :class:`.Observation` class, use `component`::
+
+        for cur_obs in sim.observations:
+            # Allocate a new TOD for the dipole alone
+            cur_obs.dipole_tod = np.zeros_like(cur_obs.tod)
+
+        # Ask `add_dipole_to_observations` to store the dipole
+        # in `obs.dipole_tod`
+        add_dipole_to_observations(sim.observations, component="dipole_tod")
     """
 
     if pointings is None:
@@ -291,7 +303,7 @@ def add_dipole_to_observations(
             frequency_ghz = np.repeat(frequency_ghz, cur_obs.tod.shape[0])
 
         add_dipole(
-            tod=cur_obs.tod,
+            tod=getattr(cur_obs, component),
             pointings=cur_ptg,
             velocity=velocity,
             t_cmb_k=t_cmb_k,

--- a/litebird_sim/madam.py
+++ b/litebird_sim/madam.py
@@ -184,7 +184,9 @@ def save_simulation_for_madam(
 
     If you want to create a map using just a subset of the components listed in the
     `components` parameter, list them in `components_to_bin`. (This is usually
-    employed when you pass ``save_pointings=False`` and ``save_tods=False``.)
+    employed when you pass ``save_pointings=False`` and ``save_tods=False``.) If
+    `components_to_bin` is ``None`` (the default), all the elements in `components`
+    will be used.
 
     If you are using MPI, call this function on *all* the MPI processes, not just on
     the one with rank #0.

--- a/litebird_sim/noise.py
+++ b/litebird_sim/noise.py
@@ -212,7 +212,7 @@ def add_noise_to_observations(
             cur_obs.noise_tod = np.zeros_like(cur_obs.tod)
 
         # Ask `add_noise_to_observations` to store the noise
-        # in `obs.dipole_tod`
+        # in `obs.noise_tod`
         add_noise_to_observations(sim.observations, …, component="noise_tod")
 
     See :func:`.add_noise` for more information.

--- a/litebird_sim/noise.py
+++ b/litebird_sim/noise.py
@@ -193,6 +193,7 @@ def add_noise_to_observations(
     noise_type: str,
     scale: float = 1.0,
     random: Union[np.random.Generator, None] = None,
+    component: str = "tod",
 ):
     """Add noise of the defined type to the observations in obs
 
@@ -202,6 +203,17 @@ def add_noise_to_observations(
     :class:`.Simulation` object. Unlike :func:`.add_noise`, it is not needed to
     pass the noise parameters here, as they are taken from the characteristics of
     the detectors saved in `obs`.
+
+    By default, the noise is added to ``Observation.tod``. If you want to add it to some
+    other field of the :class:`.Observation` class, use `component`::
+
+        for cur_obs in sim.observations:
+            # Allocate a new TOD for the noise alone
+            cur_obs.noise_tod = np.zeros_like(cur_obs.tod)
+
+        # Ask `add_noise_to_observations` to store the noise
+        # in `obs.dipole_tod`
+        add_noise_to_observations(sim.observations, …, component="noise_tod")
 
     See :func:`.add_noise` for more information.
     """
@@ -214,15 +226,15 @@ def add_noise_to_observations(
         obs_list = obs
 
     # iterate through each observation
-    for i, ob in enumerate(obs_list):
+    for i, cur_obs in enumerate(obs_list):
         add_noise(
-            tod=ob.tod,
+            tod=getattr(cur_obs, component),
             noise_type=noise_type,
-            sampling_rate_hz=ob.sampling_rate_hz,
-            net_ukrts=ob.net_ukrts,
-            fknee_mhz=ob.fknee_mhz,
-            fmin_hz=ob.fmin_hz,
-            alpha=ob.alpha,
+            sampling_rate_hz=cur_obs.sampling_rate_hz,
+            net_ukrts=cur_obs.net_ukrts,
+            fknee_mhz=cur_obs.fknee_mhz,
+            fmin_hz=cur_obs.fmin_hz,
+            alpha=cur_obs.alpha,
             scale=scale,
             random=random,
         )

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -91,6 +91,7 @@ def scan_map_in_observations(
     maps: Dict[str, np.ndarray],
     pointings: Union[np.ndarray, List[np.ndarray], None] = None,
     input_map_in_galactic: bool = True,
+    component: str = "tod",
 ):
     """Scan a map filling time-ordered data
 
@@ -99,6 +100,18 @@ def scan_map_in_observations(
     bed a :class:`.Observation` instance and a NumPy matrix, or a list
     of observations and a list of NumPy matrices; in the latter case, they must have
     the same number of elements.
+
+    By default, the signal is added to ``Observation.tod``. If you want to add it to
+    some other field of the :class:`.Observation` class, use `component`::
+
+        for cur_obs in sim.observations:
+            # Allocate a new TOD for the sky signal alone
+            cur_obs.sky_tod = np.zeros_like(cur_obs.tod)
+
+        # Ask `add_noise_to_observations` to store the noise
+        # in `obs.sky_tod`
+        scan_map_in_observations(sim.observations, …, component="sky_tod")
+
     """
 
     if pointings is None:
@@ -152,7 +165,7 @@ def scan_map_in_observations(
             input_names = None
 
         scan_map(
-            tod=cur_obs.tod,
+            tod=getattr(cur_obs, component),
             pointings=cur_ptg,
             pol_angle=cur_psi,
             maps=maps,

--- a/templates/madam_parameter_file.txt
+++ b/templates/madam_parameter_file.txt
@@ -1,6 +1,6 @@
 simulation    = {{ simulation_file_name }}
 
-{% for cur_component in components %}
+{% for cur_component in components_to_bin %}
 tod_{{ loop.index }} = {{ cur_component }}
 {% endfor %}
 

--- a/templates/madam_parameter_file.txt
+++ b/templates/madam_parameter_file.txt
@@ -1,3 +1,6 @@
+# Parameter file for Madam
+# Created by litebird_sim on {{ current_date }}
+
 simulation    = {{ simulation_file_name }}
 
 {% for cur_component in components_to_bin %}

--- a/templates/madam_parameter_file.txt
+++ b/templates/madam_parameter_file.txt
@@ -1,5 +1,8 @@
 simulation    = {{ simulation_file_name }}
-tod_1         = tod
+
+{% for cur_component in components %}
+tod_{{ loop.index }} = {{ cur_component }}
+{% endfor %}
 
 # Detectors
 {% for det in detectors %}

--- a/templates/madam_simulation_file.txt
+++ b/templates/madam_simulation_file.txt
@@ -3,10 +3,10 @@
 
 fsample = {{ sampling_rate_hz }}
 nofiles = {{ number_of_files }}
-label_start = 0
-label_end = {{ number_of_files - 1 }}
 
-tod_info = 1 1.0 tod
+{% for cur_component in components %}
+tod_info = {{ loop.index }} 1.0 {{ cur_component }}
+{% endfor %}
 
 #
 # Detectors
@@ -27,8 +27,12 @@ file_point = {{ pnt.det_id }} {{ pnt.file_name }}
 #
 # TOD
 
-path_tod = 1 {{ tod_path }}
+{% for cur_component in components %}
+path_tod = {{ loop.index }} {{ tod_path }}
 
+{% set outer_index = loop.index %}
 {% for tod in tod_files %}
-file_tod = 1 {{ tod.det_id }} {{ tod.file_name }}
+file_tod = {{ outer_index }} {{ tod.det_id }} {{ tod.file_name }}[{{ outer_index }}]
+{% endfor %}
+
 {% endfor %}

--- a/templates/madam_simulation_file.txt
+++ b/templates/madam_simulation_file.txt
@@ -4,7 +4,7 @@
 fsample = {{ sampling_rate_hz }}
 nofiles = {{ number_of_files }}
 
-{% for cur_component in components %}
+{% for cur_component in components_to_save %}
 tod_info = {{ loop.index }} 1.0 {{ cur_component }}
 {% endfor %}
 
@@ -27,7 +27,7 @@ file_point = {{ pnt.det_id }} {{ pnt.file_name }}
 #
 # TOD
 
-{% for cur_component in components %}
+{% for cur_component in components_to_save %}
 path_tod = {{ loop.index }} {{ tod_path }}
 
 {% set outer_index = loop.index %}

--- a/templates/madam_simulation_file.txt
+++ b/templates/madam_simulation_file.txt
@@ -21,7 +21,7 @@ detector_info = {{ "%5d" | format(loop.index) }} 0.0 T {{ det.net_ukrts }} {{ de
 path_point = {{ pointings_path }}
 
 {% for pnt in pointing_files %}
-file_point = {{ pnt.det_id }} {{ pnt.file_name }}
+file_point = {{ pnt.det_id }} {{ pnt.file_name }}[1]
 {% endfor %}
 
 #


### PR DESCRIPTION
Many modules in the framework directly write into `Observation.tod`, but in simulations it's often the case that we want to save components of the TOD file separately. This PR introduces the "components" keyword to a number of modules:

- [x] Madam output
- [x] Dipole
- [x] Map scanning
- [x] Noise
- [x] `make_bin_map`

