### PR TITLE
Add flag for coordinate system choice of madam output maps

### DIFF
--- a/litebird_sim/madam.py
+++ b/litebird_sim/madam.py
@@ -10,6 +10,7 @@ import jinja2
 
 import litebird_sim
 from . import DetectorInfo
+from .coordinates import CoordinateSystem
 from .mapping import DestriperParameters
 from .mpi import MPI_COMM_WORLD
 from .observations import Observation
@@ -444,6 +445,7 @@ def save_simulation_for_madam(
             "madam_cov_file_name": "cov.fits" if params.return_npp else "",
             "madam_hit_file_name": "hits.fits" if params.return_hit_map else "",
             "iter_max": params.iter_max,
+            "out_map_in_galactic": "T" if params.coordinate_system == CoordinateSystem.Galactic else "F",
         }
 
         with simulation_file_path.open("wt") as outf:

--- a/templates/madam_parameter_file.txt
+++ b/templates/madam_parameter_file.txt
@@ -17,6 +17,7 @@ kfirst        =   T
 ksecond       =   F
 kfilter       =   F
 iter_max      =   {{ iter_max }}
+to_galactic   =   {{ out_map_in_galactic }}
 
 # Baseline length
 base_first    =  {{ samples_per_baseline }}   # These are *samples*, not seconds!


### PR DESCRIPTION
Now, the `save_simulation_for_madam` function does not allow to choose, in the `madam.par` parameter file, the coordinate system of the maps produced by the Madam mapmaker. This PR adds the possibility to tell Madam to produce maps in Ecliptic or Galactic coordinates.