### PR TITLE
Add links to SSDC website in reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Add a link to the IMO webpage @SSDC for each entity/quantity/data file included in simulation reports [#211](https://github.com/litebird/litebird_sim/pull/211)
+
 -   Fix issue #209 [#210](https://github.com/litebird/litebird_sim/pull/210)
 
 -   Add flag for coordinate system choice of madam output maps [#208](https://github.com/litebird/litebird_sim/pull/208)

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -35,6 +35,8 @@ from markdown_katex import KatexExtension
 from .scanning import ScanningStrategy, SpinningScanningStrategy
 
 
+DEFAULT_BASE_IMO_URL = "https://litebirdimo.ssdc.asi.it"
+
 OutputFileRecord = namedtuple("OutputFileRecord", ["path", "description"])
 
 
@@ -578,7 +580,9 @@ class Simulation:
                 OutputFileRecord(path=curpath, description="Figure")
             )
 
-    def _fill_dictionary_with_imo_information(self, dictionary: Dict[str, Any]):
+    def _fill_dictionary_with_imo_information(
+        self, dictionary: Dict[str, Any], base_imo_url: str
+    ):
         # Fill the variable "dictionary" with information about the
         # objects retrieved from the IMO. This is used when producing
         # the final report for a simulation
@@ -617,6 +621,7 @@ class Simulation:
         dictionary["quantities"] = quantities
         dictionary["data_files"] = data_files
         dictionary["warnings"] = warnings
+        dictionary["base_imo_url"] = base_imo_url
 
     def _fill_dictionary_with_code_status(self, dictionary, include_git_diff):
         # Fill the variable "dictionary" with information about the
@@ -668,7 +673,7 @@ class Simulation:
                 f"unable to save information about latest git commit in the report: {e}"
             )
 
-    def flush(self, include_git_diff=True):
+    def flush(self, include_git_diff=True, base_imo_url: str = DEFAULT_BASE_IMO_URL):
         """Terminate a simulation.
 
         This function must be called when a simulation is complete. It
@@ -680,7 +685,9 @@ class Simulation:
         """
 
         dictionary = {"datetime": datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
-        self._fill_dictionary_with_imo_information(dictionary)
+        self._fill_dictionary_with_imo_information(
+            dictionary, base_imo_url=base_imo_url
+        )
         self._fill_dictionary_with_code_status(dictionary, include_git_diff)
 
         template_file_path = get_template_file_path("report_appendix.md")

--- a/templates/report_appendix.md
+++ b/templates/report_appendix.md
@@ -1,45 +1,41 @@
 ## Instrument model objects
 
-{% if entities -%}
-
+{% if entities %}
 ### Entities
 
 Name                 | UUID
 -------------------- | --------------------------------------------------
 {% for obj in entities -%}
-{{"%-20s"|format(obj.name)}} | [{{ obj.uuid }}]({{ base_imo_url }}/browse/entities/{{ obj.uuid }}/)
+{{ obj.name }} | [{{ obj.uuid|string|truncate(9) }}]({{ base_imo_url }}/browse/entities/{{ obj.uuid }}/)
 {% endfor -%}
 {% endif -%}
 
-{% if quantities -%}
-
+{% if quantities %}
 ### Quantities
 
 Name                 | UUID
 -------------------- | --------------------------------------------------
 {% for obj in quantities -%}
-{{"%-20s"|format(obj.name)}} | [{{ obj.uuid }}]({{ base_imo_url }}/browse/quantities/{{ obj.uuid }}/)
+{{ obj.name }} | [{{ obj.uuid|string|truncate(9) }}]({{ base_imo_url }}/browse/quantities/{{ obj.uuid }}/)
 {% endfor -%}
 {% endif -%}
 
-{% if data_files -%}
-
+{% if data_files %}
 ### Data Files
 
 Name                 | UUID                                 | Upload date
 -------------------- | ------------------------------------ | ------------
 {% for obj in data_files -%}
-{{"%-20s"|format(obj.name)}} | [{{ obj.uuid }}]({{ base_imo_url }}/browse/data_files/{{ obj.uuid }}/) | {{ obj.upload_date }}
+{{ obj.name }} | [{{ obj.uuid|string|truncate(9) }}]({{ base_imo_url }}/browse/data_files/{{ obj.uuid }}/) | {{ obj.upload_date }}
 {% endfor -%}
 {% endif -%}
 
-{% if warnings -%}
-
+{% if warnings %}
 ### Warnings
 
 {% for w in warnings -%}
--   {{ w[0].uuid|string|truncate(9) }} ({{ w[0].upload_date }}) has been
-    superseded by {{ w[1].uuid }} ({{ w[1].upload_date }})
+-   [{{ w[0].uuid|string|truncate(9) }}]({{ base_imo_url }}/browse/data_files/{{ w[0].uuid }}/) ({{ w[0].upload_date }}) has been
+    superseded by [{{ w[1].uuid|string|truncate(9) }}]({{ base_imo_url }}/browse/data_files/{{ w[1].uuid }}/) ({{ w[1].upload_date }})
 {% endfor -%}
 {% endif %}
 
@@ -48,8 +44,8 @@ Name                 | UUID                                 | Upload date
 -   Main repository: [github.com/litebird/litebird_sim](https://github.com/litebird/litebird_sim)
 -   Version: {{ litebird_sim_version }}, by {{ litebird_sim_author }}
 {% if short_commit_hash -%}
--   Commit hash: [{{ short_commit_hash }}](https://github.com/litebird/litebird_sim/commit/{commit_hash})
-    (_{{ commit_message }}_, by {{ author }})
+-   Commit hash: [{{ short_commit_hash }}](https://github.com/litebird/litebird_sim/commit/{{commit_hash}})
+    (commit comment: *{{ commit_message }}*, by {{ author }})
 {% endif %}
 
 {% if skip_code_diff %}

--- a/templates/report_appendix.md
+++ b/templates/report_appendix.md
@@ -7,7 +7,7 @@
 Name                 | UUID
 -------------------- | --------------------------------------------------
 {% for obj in entities -%}
-{{"%-20s"|format(obj.name)}} | {{ obj.uuid }}
+{{"%-20s"|format(obj.name)}} | [{{ obj.uuid }}]({{ base_imo_url }}/browse/entities/{{ obj.uuid }}/)
 {% endfor -%}
 {% endif -%}
 
@@ -18,7 +18,7 @@ Name                 | UUID
 Name                 | UUID
 -------------------- | --------------------------------------------------
 {% for obj in quantities -%}
-{{"%-20s"|format(obj.name)}} | {{ obj.uuid }}
+{{"%-20s"|format(obj.name)}} | [{{ obj.uuid }}]({{ base_imo_url }}/browse/quantities/{{ obj.uuid }}/)
 {% endfor -%}
 {% endif -%}
 
@@ -29,7 +29,7 @@ Name                 | UUID
 Name                 | UUID                                 | Upload date
 -------------------- | ------------------------------------ | ------------
 {% for obj in data_files -%}
-{{"%-20s"|format(obj.name)}} | {{ obj.uuid }} | {{ obj.upload_date }}
+{{"%-20s"|format(obj.name)}} | [{{ obj.uuid }}]({{ base_imo_url }}/browse/data_files/{{ obj.uuid }}/) | {{ obj.upload_date }}
 {% endfor -%}
 {% endif -%}
 


### PR DESCRIPTION
With this PR, the report produced by `Simulation.flush` will link every IMO object to its counterpart in the IMO website, which defaults to the one maintained by the ASI SSDC (password protected).
