### PR TITLE
Temporarily disable mpich

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        mpi: ["none", mpich, openmpi]
+        mpi: ["none", openmpi] # mpich
         python: [3.7, 3.9]
         exclude:
           - os: macos-latest


### PR DESCRIPTION
It has been a few weeks that tests using mpich take forever to compile. It's hard to investigate this, because it might likely be due to some outdated dependencies. I would prefer to disable mpich tests until we deprecate Python 3.7 and update all our dependencies; keeping mpich tests enabled might suck up all the free time to run CI builds.
