### PR TITLE
Add support for multiple TODs in `describe_mpi_distribution`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # HEAD
 
-    -   Implement new methods in the `Simulation` class: `set_scanning_strategy`, `set_instrument`, `set_hwp`, and deprecate `generate_spin2ecl_quaternions` [#217](https://github.com/litebird/litebird_sim/pull/217)
+-   **Breaking change**: add multiple TOD support to `describe_mpi_distribution` and make the field `MpiObservationDescr.tod_dtype` a list of strings [#220](https://github.com/litebird/litebird_sim/pull/220)
+
+-   Implement new methods in the `Simulation` class: `set_scanning_strategy`, `set_instrument`, `set_hwp`, and deprecate `generate_spin2ecl_quaternions` [#217](https://github.com/litebird/litebird_sim/pull/217)
 
 -   Add `gzip_compression` keyword to `write_observations` [#214](https://github.com/litebird/litebird_sim/pull/214)
 

--- a/docs/source/simulations.rst
+++ b/docs/source/simulations.rst
@@ -385,15 +385,17 @@ example:
     - Start time: 0.0
     - Duration: 21600.0 s
     - 1 detector(s) (0A)
+    - TOD(s): tod
     - TOD shape: 1×216000
-    - TOD dtype: float64
+    - Types of the TODs: float64
 
     ## Observation #1
     - Start time: 43200.0
     - Duration: 21600.0 s
     - 1 detector(s) (0A)
+    - TOD(s): tod
     - TOD shape: 1×216000
-    - TOD dtype: float64
+    - Types of the TODs: float64
 
     # MPI rank #2
 
@@ -401,15 +403,17 @@ example:
     - Start time: 21600.0
     - Duration: 21600.0 s
     - 1 detector(s) (0A)
+    - TOD(s): tod
     - TOD shape: 1×216000
-    - TOD dtype: float64
+    - Types of the TODs: float64
 
     ## Observation #1
     - Start time: 64800.0
     - Duration: 21600.0 s
     - 1 detector(s) (0A)
+    - TOD(s): tod
     - TOD shape: 1×216000
-    - TOD dtype: float64
+    - Types of the TODs: float64
 
     # MPI rank #3
 
@@ -417,15 +421,17 @@ example:
     - Start time: 0.0
     - Duration: 21600.0 s
     - 1 detector(s) (0B)
+    - TOD(s): tod
     - TOD shape: 1×216000
-    - TOD dtype: float64
+    - Types of the TODs: float64
 
     ## Observation #1
     - Start time: 43200.0
     - Duration: 21600.0 s
     - 1 detector(s) (0B)
+    - TOD(s): tod
     - TOD shape: 1×216000
-    - TOD dtype: float64
+    - Types of the TODs: float64
 
     # MPI rank #4
 
@@ -433,15 +439,17 @@ example:
     - Start time: 21600.0
     - Duration: 21600.0 s
     - 1 detector(s) (0B)
+    - TOD(s): tod
     - TOD shape: 1×216000
-    - TOD dtype: float64
+    - Types of the TODs: float64
 
     ## Observation #1
     - Start time: 64800.0
     - Duration: 21600.0 s
     - 1 detector(s) (0B)
+    - TOD(s): tod
     - TOD shape: 1×216000
-    - TOD dtype: float64
+    - Types of the TODs: float64
 
 The class :class:`.MpiDistributionDescr` contains a list
 of :class:`.MpiProcessDescr`, which describe the «contents»

--- a/litebird_sim/madam.py
+++ b/litebird_sim/madam.py
@@ -209,7 +209,7 @@ def save_simulation_for_madam(
     # Simulation.describe_mpi_distribution(), which returns a
     # description of the way observations are spread among the
     # MPI processes. This is *vital* to build correct FITS files
-    # for Madam, as the TODs of each detectors must be saved in
+    # for Madam, as the TODs of each detector must be saved in
     # files whose names contain an increasing integer index. We
     # use `distribution` to properly compute these indexes.
     #
@@ -244,7 +244,7 @@ def save_simulation_for_madam(
     if not components_to_bin:
         components_to_bin = components
 
-    distribution = sim.describe_mpi_distribution()
+    distribution = sim.describe_mpi_distribution(tod_names=components)
     assert distribution is not None
 
     if detectors is not None:

--- a/test/test_madam.py
+++ b/test/test_madam.py
@@ -38,8 +38,9 @@ def test_sort_obs_per_det():
                 observations=[
                     MpiObservationDescr(
                         det_names=["A"],
+                        tod_names=["tod"],
                         tod_shape=(0, 0),
-                        tod_dtype="float32",
+                        tod_dtype=["float32"],
                         start_time=2.0,
                         duration_s=1.0,
                         num_of_samples=1,
@@ -47,8 +48,9 @@ def test_sort_obs_per_det():
                     ),
                     MpiObservationDescr(
                         det_names=["A"],
+                        tod_names=["tod"],
                         tod_shape=(0, 0),
-                        tod_dtype="float32",
+                        tod_dtype=["float32"],
                         start_time=0.0,
                         duration_s=1.0,
                         num_of_samples=1,
@@ -61,8 +63,9 @@ def test_sort_obs_per_det():
                 observations=[
                     MpiObservationDescr(
                         det_names=["A"],
+                        tod_names=["tod"],
                         tod_shape=(0, 0),
-                        tod_dtype="float32",
+                        tod_dtype=["float32"],
                         start_time=1.0,
                         duration_s=1.0,
                         num_of_samples=1,
@@ -70,8 +73,9 @@ def test_sort_obs_per_det():
                     ),
                     MpiObservationDescr(
                         det_names=["A"],
+                        tod_names=["tod"],
                         tod_shape=(0, 0),
-                        tod_dtype="float32",
+                        tod_dtype=["float32"],
                         start_time=3.0,
                         duration_s=1.0,
                         num_of_samples=1,


### PR DESCRIPTION
This PR adds support for multiple TODs in `describe_mpi_distribution`. Apart from the possibility to include other TODs in the computation of the allocated memory, this lets one to skip the field `Observation.tod`, in those cases where it is not allocated, through the use of the new keyword `tod_names`.

There is a small breaking change here, because now the field `tod_dtype` of the class `MpiProcessDescr` is a list of strings instead of a plain string. (This is required, because once multiple TODs are present, it is possible that they have different data types.)

- [X] Add support for multiple TODs in describe_mpi_distribution
- [X] Add new tests
- [X] Document the changes
