### PR TITLE
Implement multi-core threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Add support for partial multithreading using Numba [#276](https://github.com/litebird/litebird_sim/pull/276)
+
 # Version 0.11.0
 
 -   **Breaking change**: Change the interface to the binner, implement a new destriper, and make the dependency on TOAST optional [#260](https://github.com/litebird/litebird_sim/pull/260)

--- a/docs/source/mpi.rst
+++ b/docs/source/mpi.rst
@@ -1,7 +1,92 @@
 .. _using_mpi:
 
-Using MPI
-=========
+Multithreading and MPI
+======================
+
+As typical operations on time-ordered data can be quite consuming,
+the LiteBIRD Simulation Framework provides a number of tools to
+exploit the presence of multiple CPU cores and even multiple
+computing nodes. This section details how to take advantage
+of these facilities and is split in two parts:
+
+- We will first present the ability of the framework to use multiple
+  CPU threads; in this context, the data samples are kept in a chunk
+  of memory that is shared between several processes. The framework
+  uses Numba, which can take advantage either of the `Intel
+  Threading Building Blocks <https://www.intel.com/content/www/us/en/developer/tools/oneapi/onetbb.html>`_
+  library or of `OpenMP <https://www.openmp.org/>`_.
+
+- Then, we will discuss the possibility to run the code on
+  multiple *computing nodes*, where the memory of each node is
+  **not** shared with the others. The framework is able to
+  use any MPI library, through the Python package
+  `mpi4py <https://mpi4py.readthedocs.io/en/stable/>`_.
+
+
+Multithreading
+~~~~~~~~~~~~~~
+
+The LiteBIRD Simulation Framework is able to exploit multiple cores
+because several of its modules  rely on the `Numba
+<https://numba.pydata.org/>`_ library.
+
+If you are running your code on your multi-core laptop, you do not
+have to do anything fancy in order to use all the CPUs on your machine:
+in its default configuration, the Framework should be able to take
+advantage all the available CPU cores.
+
+However, if you want to tune the way the Framework uses the CPUs,
+the constructor of the class :class:`.Simulation` accepts two
+parameters meant for this purpose:
+
+- `numba_num_of_threads`: this is the number of CPUs that Numba will
+  use for parallel calculations. The parameter defaults to ``None``,
+  which means that Numba will check how many CPUs are available and will
+  use all of them.
+
+- `numba_threading_layer`: this parameter is a string that specifies
+  which threading library should be used by Numba. The value depends
+  both on the version of Numba you are running and on the availability
+  of these libraries, as they are not installed together with the
+  LiteBIRD Simulation Framework. Numba 0.53 provides the following choices:
+
+  - ``tbb``: `Intel Threading Building Blocks
+    <https://www.intel.com/content/www/us/en/developer/tools/oneapi/onetbb.html>`_.
+    You should pick this if you are running your code on Intel machines and the
+    Tbb library is available.
+
+  - ``omp``: `OpenMP <https://www.openmp.org/>`_. If you pick this one,
+    be sure that the OpenPM library is available.
+
+  - ``workqueue``: this is an internal threading library provided by Numba.
+    It's probably the least efficient of the three; its main advantage is
+    that it is always available.
+
+These parameters can be passed through a TOML parameter file (see
+:ref:`parameter_files`) as well:
+
+.. code-block:: toml
+
+   # This is file "my_conf.toml"
+   [simulation]
+   random_seed = 12345
+   numba_num_of_threads = 32
+   numba_threading_layer = "tbb"
+
+Both ``tbb`` and ``omp`` require that the relevant library be available on
+your system, as the command ``pip install litebird_sim`` does **not** install
+them. If you are running your code on a HPC cluster, it is probably a matter
+of running a command like the following:
+
+.. code-block:: sh
+
+   # This might change depending on how the environment on your cluster
+   # is configured; the following commands are just examples.
+   $ module load tbb     # Intel Threading Building Blocks
+   $ module load openmp  # OpenMP
+
+MPI
+~~~
 
 The LiteBIRD Simulation Framework lists mpi4py as an *optional*
 dependency. This means that simulation codes should be able to cope

--- a/docs/source/mpi.rst
+++ b/docs/source/mpi.rst
@@ -26,9 +26,9 @@ of these facilities and is split in two parts:
 Multithreading
 ~~~~~~~~~~~~~~
 
-The LiteBIRD Simulation Framework is able to exploit multiple cores
-because several of its modules  rely on the `Numba
-<https://numba.pydata.org/>`_ library.
+Some parts of the LiteBIRD Simulation Framework are able to
+exploit multiple cores because several of its modules rely on
+the `Numba <https://numba.pydata.org/>`_ library.
 
 If you are running your code on your multi-core laptop, you do not
 have to do anything fancy in order to use all the CPUs on your machine:
@@ -36,8 +36,9 @@ in its default configuration, the Framework should be able to take
 advantage all the available CPU cores.
 
 However, if you want to tune the way the Framework uses the CPUs,
-the constructor of the class :class:`.Simulation` accepts two
-parameters meant for this purpose:
+you can either set the environment variable ``OMP_NUM_THREADS``
+to the number of CPUs to use, or use two parameters in
+the constructor of the class :class:`.Simulation`:
 
 - `numba_num_of_threads`: this is the number of CPUs that Numba will
   use for parallel calculations. The parameter defaults to ``None``,
@@ -84,6 +85,7 @@ of running a command like the following:
    # is configured; the following commands are just examples.
    $ module load tbb     # Intel Threading Building Blocks
    $ module load openmp  # OpenMP
+
 
 MPI
 ~~~

--- a/docs/source/simulations.rst
+++ b/docs/source/simulations.rst
@@ -128,6 +128,12 @@ parameters in the section named ``simulation`` are the following:
   value ensures the reproducibility of the results obtained with random
   numbers; by passing ``None`` there will not be the possibility to
   re-obtain the same outputs. You can find more details in :ref:`random-numbers`.
+- ``numba_num_of_threads``: number of threads used by Numba when running
+  a parallel calculation.
+- ``numba_threading_layer``: the multi-threading library to be used by
+  Numba for parallel computations. See the `Numba user's manual
+  <https://numba.readthedocs.io/en/stable/user/threading-layer.html>`_ to
+  check which choices are available.
 
 These parameters can be used instead of the keywords in the
 constructor of the :class:`.Simulation` class. Consider the following
@@ -140,6 +146,8 @@ code::
       name="My simulation",
       description="A long description should be put here",
       random_seed=12345,
+      numba_num_of_threads=4,
+      numba_threading_layer="workqueue",
   )
 
 You can achieve the same if you create a TOML file named ``foo.toml``
@@ -154,6 +162,8 @@ that contains the following lines:
    name = "My simulation"
    description = "A long description should be put here"
    random_seed = 12345
+   numba_num_of_threads = 4
+   numba_threading_layer = "workqueue"
 
 and then you initialize the `sim` variable in your Python code as
 follows::

--- a/litebird_sim/__init__.py
+++ b/litebird_sim/__init__.py
@@ -84,6 +84,7 @@ from litebird_sim.mapmaking import (
     ExternalDestriperParameters,
 )
 from .simulations import (
+    NUMBA_NUM_THREADS_ENVVAR,
     Simulation,
     MpiObservationDescr,
     MpiProcessDescr,
@@ -243,6 +244,7 @@ __all__ = [
     "TOAST_ENABLED",
     "destripe_with_toast2",
     # simulations.py
+    "NUMBA_NUM_THREADS_ENVVAR",
     "Simulation",
     "MpiObservationDescr",
     "MpiProcessDescr",

--- a/litebird_sim/__init__.py
+++ b/litebird_sim/__init__.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 from pathlib import Path
+import numba
 
 from .compress import (
     rle_compress,
@@ -145,6 +146,10 @@ except ImportError:
     TOAST_ENABLED = False
 
 from .version import __author__, __version__
+
+# Privilege TBB over OpenPM and the internal Numba implementation of a
+# work queue
+numba.config.THREADING_LAYER_CONFIG = ["tbb", "omp", "workqueue"]
 
 PTEP_IMO_LOCATION = Path(__file__).parent.parent / "default_imo"
 

--- a/litebird_sim/dipole.py
+++ b/litebird_sim/dipole.py
@@ -2,7 +2,7 @@
 
 from enum import IntEnum
 
-from numba import njit
+from numba import njit, prange
 import numpy as np
 
 from typing import Union, List
@@ -128,7 +128,7 @@ def compute_dipole_for_one_sample_total_from_lin_t(
     return t_cmb_k / f_x * (planck_t / planck_t0 - 1)
 
 
-@njit
+@njit(parallel=True)
 def add_dipole_for_one_detector(
     tod_det,
     theta_det,
@@ -141,22 +141,22 @@ def add_dipole_for_one_detector(
     dipole_type: DipoleType,
 ):
     if dipole_type == DipoleType.LINEAR:
-        for i in range(len(tod_det)):
+        for i in prange(len(tod_det)):
             tod_det[i] += compute_dipole_for_one_sample_linear(
                 theta=theta_det[i], phi=phi_det[i], v_km_s=velocity[i], t_cmb_k=t_cmb_k
             )
     elif dipole_type == DipoleType.QUADRATIC_EXACT:
-        for i in range(len(tod_det)):
+        for i in prange(len(tod_det)):
             tod_det[i] += compute_dipole_for_one_sample_quadratic_exact(
                 theta=theta_det[i], phi=phi_det[i], v_km_s=velocity[i], t_cmb_k=t_cmb_k
             )
     elif dipole_type == DipoleType.TOTAL_EXACT:
-        for i in range(len(tod_det)):
+        for i in prange(len(tod_det)):
             tod_det[i] += compute_dipole_for_one_sample_total_exact(
                 theta=theta_det[i], phi=phi_det[i], v_km_s=velocity[i], t_cmb_k=t_cmb_k
             )
     elif dipole_type == DipoleType.QUADRATIC_FROM_LIN_T:
-        for i in range(len(tod_det)):
+        for i in prange(len(tod_det)):
             tod_det[i] += compute_dipole_for_one_sample_quadratic_from_lin_t(
                 theta=theta_det[i],
                 phi=phi_det[i],
@@ -166,7 +166,7 @@ def add_dipole_for_one_detector(
             )
     elif dipole_type == DipoleType.TOTAL_FROM_LIN_T:
         planck_t0 = planck(nu_hz, t_cmb_k)
-        for i in range(len(tod_det)):
+        for i in prange(len(tod_det)):
             tod_det[i] += compute_dipole_for_one_sample_total_from_lin_t(
                 theta=theta_det[i],
                 phi=phi_det[i],

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -1,22 +1,14 @@
 # -*- encoding: utf-8 -*-
 
-from numba import njit
 import numpy as np
+from numba import njit, prange
 
 from ducc0.healpix import Healpix_Base
-
-from astropy.time import Time, TimeDelta
-
 from typing import Union, List, Dict
-
 from .observations import Observation
-
 from .coordinates import rotate_coordinates_e2g, CoordinateSystem
-
 from .healpix import npix_to_nside
-
 import logging
-
 import healpy as hp
 
 
@@ -26,9 +18,9 @@ def compute_signal_for_one_sample(T, Q, U, co, si):
     return T + co * Q + si * U
 
 
-@njit
+@njit(parallel=True)
 def scan_map_for_one_detector(tod_det, input_T, input_Q, input_U, pol_angle_det):
-    for i in range(len(tod_det)):
+    for i in prange(len(tod_det)):
         tod_det[i] += compute_signal_for_one_sample(
             T=input_T[i],
             Q=input_Q[i],

--- a/litebird_sim/scanning.py
+++ b/litebird_sim/scanning.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from astropy.coordinates import ICRS, get_body_barycentric
 import astropy.time
 import astropy.units as u
-from numba import njit
+from numba import njit, prange
 import numpy as np
 
 from ducc0.pointingprovider import PointingProvider
@@ -187,7 +187,7 @@ def compute_pointing_and_polangle(result, quaternion):
     result[2] = pol_angle
 
 
-@njit
+@njit(parallel=True)
 def all_compute_pointing_and_polangle(result_matrix, quat_matrix):
     """Repeatedly apply :func:`compute_pointing_and_polangle`
 
@@ -212,7 +212,7 @@ def all_compute_pointing_and_polangle(result_matrix, quat_matrix):
     assert quat_matrix.shape[2] == 4
 
     for det_idx in range(n_dets):
-        for sample_idx in range(n_samples):
+        for sample_idx in prange(n_samples):
             compute_pointing_and_polangle(
                 result_matrix[det_idx, sample_idx, :],
                 quat_matrix[sample_idx, det_idx, :],
@@ -296,7 +296,7 @@ def spin_to_ecliptic(
     quat_left_multiply(result, *quat_rotation_z(sun_earth_angle_rad))
 
 
-@njit
+@njit(parallel=True)
 def all_spin_to_ecliptic(
     result_matrix,
     sun_earth_angles_rad,
@@ -325,7 +325,7 @@ def all_spin_to_ecliptic(
     4)``.
 
     """
-    for row in range(result_matrix.shape[0]):
+    for row in prange(result_matrix.shape[0]):
         spin_to_ecliptic(
             result=result_matrix[row, :],
             sun_earth_angle_rad=sun_earth_angles_rad[row],

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -56,6 +56,9 @@ from .scanning import ScanningStrategy, SpinningScanningStrategy
 
 DEFAULT_BASE_IMO_URL = "https://litebirdimo.ssdc.asi.it"
 
+# Name of the environment variable used to set up Numba threads
+NUMBA_NUM_THREADS_ENVVAR = "OMP_NUM_THREADS"
+
 OutputFileRecord = namedtuple("OutputFileRecord", ["path", "description"])
 
 
@@ -304,7 +307,10 @@ class Simulation:
             read into the field `parameters` (a Python dictionary).
 
         numba_threads (int): number of threads to use when calling
-            Numba functions.
+            Numba functions. If no value is passed but the environment
+            variable ``OMP_NUM_THREADS`` is set, its value will be used;
+            otherwise a number of threads equal to the number of CPU
+            cores will be used.
 
         numba_threading_layer (str): name of the Numba threading layer
             to use. See the Numba User's Manual:
@@ -354,6 +360,9 @@ class Simulation:
             self.imo = imo
         else:
             self.imo = Imo()
+
+        if not numba_threads and NUMBA_NUM_THREADS_ENVVAR in os.environ:
+            numba_threads = int(os.environ[NUMBA_NUM_THREADS_ENVVAR])
 
         self.numba_threads = numba_threads
         self.numba_threading_layer = numba_threading_layer

--- a/test/test_madam.py
+++ b/test/test_madam.py
@@ -35,6 +35,7 @@ def test_sort_obs_per_det():
         mpi_processes=[
             MpiProcessDescr(
                 mpi_rank=0,
+                numba_num_of_threads=1,
                 observations=[
                     MpiObservationDescr(
                         det_names=["A"],
@@ -62,6 +63,7 @@ def test_sort_obs_per_det():
             ),
             MpiProcessDescr(
                 mpi_rank=1,
+                numba_num_of_threads=1,
                 observations=[
                     MpiObservationDescr(
                         det_names=["A"],


### PR DESCRIPTION
This PR tests how to exploit Numba's multithreading capabilities to parallelize some modules in the framework. Only the most trivial computations are parallelized here, as the primary purpose of this PR is to provide the foundations for a more efficient approach to multithreading.

- [X] Configure Numba threading layers
- [X] Update Simulation.__init__() and MpiProcessDescr
- [X] Parallelize the pointing generation code
- [X] Parallelize the dipole code
- [X] Parallelize the map scanning code
- [X] Add (partial) multithreading support to the destriper
- [X] Update the documentation

The modifications I have done to the code are the following:

-   The `Simulation.__init__()` constructor now accepts two new parameters:
    - `numba_num_of_threads`: number of threads to use, defaults to the number of available CPUs;
    - `numba_threading_layer`: here you specify if you want to use TBB, OpenPM, or Numba's internal implementation.
    These parameters can be specified in the TOML parameter file too.
-   The `Simulation.describe_mpi_distribution()` function now returns information about the number of threads allocated by each MPI process as well.
-   Pointing generation and dipole computation employ `Numba.prange()` and pass `parallel=True` to `@njit` to make a few critical `for` loops parallelized over CPU threads.
-   The destriper was fixed only in a few places, as only a handful of `for` loops can be parallelized (too many inter-dependencies).
