### PR TITLE
Improve the documentation about NET and noise simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Improve the documentation about noise simulations [#283](https://github.com/litebird/litebird_sim/pull/283)
+
 -   Move from `flake8`/`black` to `ruff` [#281](https://github.com/litebird/litebird_sim/pull/281/)
 
 -   New module to simulate HWP systematics [#232](https://github.com/litebird/litebird_sim/pull/232)

--- a/docs/source/timeordered.rst
+++ b/docs/source/timeordered.rst
@@ -290,6 +290,19 @@ Again, to generate noise with custom parameters, we can either use the low-level
    lbs.noise.add_noise_to_observations(obs, 'one_over_f', random=sim.random)
 
 
+.. warning::
+
+    Be sure you understand the difference between the noise level in a
+    timestream and the noise level in a map. Although of course the
+    latter depends on the former, the conversion depends on several factors.
+
+    A common mistake is to scale the noise level in maps by the mission time
+    divided by the number of pixels in themap. Using this number in a call to
+    :func:`.add_white_noise` is **wrong**, as the noise level per pixel depends
+    on the overall integration time, which is always less than the mission time
+    because of cosmic ray loss, repointing maneuvers, etc.
+
+
 Methods of class simulation
 ---------------------------
 

--- a/docs/source/timeordered.rst
+++ b/docs/source/timeordered.rst
@@ -296,15 +296,16 @@ Again, to generate noise with custom parameters, we can either use the low-level
     timestream and the noise level in a map. Although of course the
     latter depends on the former, the conversion depends on several factors.
 
-    A common mistake is to scale the noise level in maps by the mission time
-    divided by the number of pixels in themap. Using this number in a call to
-    :func:`.add_white_noise` is **wrong**, as the noise level per pixel depends
-    on the overall integration time, which is always less than the mission time
-    because of cosmic ray loss, repointing maneuvers, etc.
+    A common mistake is use the mission time divided by the number of pixels in
+    the map in a call to :func:`.add_white_noise`. This is **wrong**, as the noise
+    level per pixel depends on the overall integration time, which is always
+    less than the mission time because of cosmic ray loss, repointing maneuvers, etc.
+    These effects reduce the number of samples in the timeline that can be used to
+    estimate the map, but they do not affect the noise of the timeline.
 
 
-Methods of class simulation
----------------------------
+Methods of the Simulation class
+-------------------------------
 
 The class :class:`.Simulation` provides two simple functions that fill
 with sky signal and noise all the observations of a given simulation.

--- a/litebird_sim/detectors.py
+++ b/litebird_sim/detectors.py
@@ -54,6 +54,7 @@ class DetectorInfo:
 
         - sampling_rate_hz (float): The sampling rate of the ADC
              associated with this detector. The default is 0.0
+
         - fwhm_arcmin: (float): The Full Width Half Maximum of the
              radiation pattern associated with the detector, in
              arcminutes. The default is 0.0
@@ -63,10 +64,14 @@ class DetectorInfo:
 
         - net_ukrts (float): The noise equivalent temperature of the
              signal produced by the detector in nominal conditions,
-             expressed in μK/√s.. The default is 0.0
+             expressed in μK/√s. This is the noise per sample to be
+             used when adding noise to the timelines. The default is 0.0
 
         - pol_sensitivity_ukarcmin (float): The detector sensitivity
-            in microK_arcmin. The default is 0.0
+            in microK_arcmin. This value considers the effect of cosmic ray loss,
+            repointing maneuvers, etc., and other issues that cause loss of
+            integration time. Therefore, it should **not** be used with the
+            functions that add noise to the timelines. The default is 0.0
 
         - bandcenter_ghz (float): The center frequency of the
              detector, in GHz. The default is 0.0

--- a/litebird_sim/noise.py
+++ b/litebird_sim/noise.py
@@ -27,7 +27,9 @@ def add_white_noise(data, sigma: float, random):
 
         `data` : 1-D numpy array
 
-        `sigma` : white noise level
+        `sigma` : the white noise level per sample. Be sure *not* to include cosmic ray
+                  loss, repointing maneuvers, etc., as these affect the integration time
+                  but **not** the white noise per sample.
 
         `random` : a random number generator that implements the ``normal`` method.
                    You should typically use the `random` field of a :class:`.Simulation`
@@ -73,7 +75,9 @@ def add_one_over_f_noise(
 
         `alpha` : low frequency spectral tilt
 
-        `sigma` : white noise level
+        `sigma` : the white noise level per sample. Be sure *not* to include cosmic ray
+                  loss, repointing maneuvers, etc., as these affect the integration time
+                  but **not** the white noise per sample.
 
         `sampling_rate_hz` : the sampling frequency of the data
 
@@ -123,6 +127,10 @@ def add_noise(
 
     The parameter `noisetype` must either be ``white`` or ``one_over_f``; in the latter
     case, the noise will contain a 1/f part and a white noise part.
+
+    Be sure *not* to include cosmic ray loss, repointing maneuvers, etc., in the value
+    passed as `net_ukrts`, as these affect the integration time but **not** the white
+    noise per sample.
 
     The parameter `scale` can be used to introduce measurement unit conversions when
     appropriate. Default units: [K].


### PR DESCRIPTION
This PR addresses the issue mentioned in action 2023-021: it can be confusing to determine which of the parameters describing the noise should be used when calling `add_noise` in the framework. I added explanations both in the User's manual and in a few docstrings to make this problem clearer to the user.
