### PR TITLE
Components added to functions of class Simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Include the possibility to pass components to fill_tods,  add_dipole and add_noise [#302](https://github.com/litebird/litebird_sim/issues/302)
+
 -   Fixing bug in mbs to pass general bandpass to mbs [#271](https://github.com/litebird/litebird_sim/pull/271) 
 
 -   **Breaking change**: Reworking of the IO, `write_observations` and `read_observations` are now part of the class simulation [#293](https://github.com/litebird/litebird_sim/pull/293)  

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -1305,6 +1305,7 @@ class Simulation:
         self,
         maps: Dict[str, np.ndarray],
         input_map_in_galactic: bool = True,
+        component: str = "tod",
         interpolation: Union[str, None] = "",
         append_to_report: bool = True,
     ):
@@ -1320,6 +1321,7 @@ class Simulation:
             self.observations,
             maps=maps,
             input_map_in_galactic=input_map_in_galactic,
+            component=component,
             interpolation=interpolation,
         )
 
@@ -1356,6 +1358,7 @@ class Simulation:
         t_cmb_k: float = constants.T_CMB_K,
         dipole_type: DipoleType = DipoleType.TOTAL_FROM_LIN_T,
         append_to_report: bool = True,
+        component: str = "tod",
     ):
         """Fills the tod with dipole.
 
@@ -1373,6 +1376,7 @@ class Simulation:
             pos_and_vel=self.pos_and_vel,
             t_cmb_k=t_cmb_k,
             dipole_type=dipole_type,
+            component=component,
         )
 
         if append_to_report and MPI_COMM_WORLD.rank == 0:
@@ -1398,6 +1402,7 @@ class Simulation:
         random: np.random.Generator,
         noise_type: str = "one_over_f",
         append_to_report: bool = True,
+        component: str = "tod",
     ):
         """Adds noise to tods.
 
@@ -1413,6 +1418,7 @@ class Simulation:
             obs=self.observations,
             noise_type=noise_type,
             random=random,
+            component=component,
         )
 
         if append_to_report and MPI_COMM_WORLD.rank == 0:


### PR DESCRIPTION
This PR address issues #302. Now it s possible to pass components to `fill_tods`,  `add_dipole` and `add_noise`. 