### PR TITLE
Change the default behavior of Simulation.add_noise()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@
 
 -   Make the code compatible with Python 3.12 [#332](https://github.com/litebird/litebird_sim/pull/332)
 
--  plot_fp.py which visualizes focal plane and `DetectorInfo` is implemented. 
+-   plot_fp.py which visualizes focal plane and `DetectorInfo` is implemented. 
 Also it can generate a dector list file by clicking visualized detectors. 
 The function is executable by: `python -m litebird_sim.plot_fp` [#345](https://github.com/litebird/litebird_sim/pull/345)
+
+-   Simulation.add_noise() uses self.random as default random number generator [#349](https://github.com/litebird/litebird_sim/pull/349)
 
 # Version 0.13.0
 

--- a/docs/source/map_scanning.rst
+++ b/docs/source/map_scanning.rst
@@ -174,7 +174,7 @@ transparent:
 
   sim.fill_tods(sky_signal)
 
-  sim.add_noise(noise_type='white', random=sim.random)
+  sim.add_noise(noise_type='white')
 
   for i in range(5):
       print(f"{sim.observations[0].tod[0][i]:.5e}")

--- a/docs/source/noise.rst
+++ b/docs/source/noise.rst
@@ -241,7 +241,7 @@ the interface is simplified.
 
   sim.create_observations(detectors=det)
 
-  sim.add_noise(noise_type='one_over_f', random=sim.random)
+  sim.add_noise(noise_type='one_over_f')
 
   for i in range(5):
       print(f"{sim.observations[0].tod[0][i]:.5e}")

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -1548,7 +1548,7 @@ class Simulation:
     @_profile
     def add_noise(
         self,
-        random: np.random.Generator,
+        random: Union[np.random.Generator, None] = None,
         noise_type: str = "one_over_f",
         component: str = "tod",
         append_to_report: bool = True,
@@ -1558,10 +1558,13 @@ class Simulation:
         This method must be called after having set the instrument,
         the list of detectors to simulate through calls to
         :meth:`.set_instrument` and :meth:`.add_detector`.
-        The parameter `random` must be specified and must be a random number
-        generator thatimplements the ``normal`` method. You should typically
-        use the `random` field of a :class:`.Simulation` object for this.
+        The parameter `random` can be specified as a random number
+        generator that implements the ``normal`` method. As default it uses
+        the `random` field of a :class:`.Simulation` object for this.
         """
+
+        if random is None:
+            random = self.random
 
         add_noise_to_observations(
             observations=self.observations,


### PR DESCRIPTION
Now `Simulation.add_noise()` uses self.random as default random number generator. The following syntax now works:
```
sim.add_noise()

sim.add_noise(noise_type='white')
```