### PR TITLE
Update actions/cache to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       # store it
       - name: Cache PySM3 data files
         id: cache-pysm3
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/pysm3-data
           key: pysm3-data-${{ runner.os }}-${{ matrix.python }}-${{ matrix.mpi }}-${{ secrets.CACHE_VERSION }}


### PR DESCRIPTION
This PR updates `actions/cache` to version 4, after GitHub sent the following email:

> Starting February 1st, 2025, we are closing down v1-v2 of actions/cache (read more about it in this changelog announcement) as well as all previous versions of the @actions/cache package in actions/toolkit. Attempting to use a version of the @actions/cache package or actions/cache after the announced deprecation date will result in a workflow failure. If you are pinned to a specific version or SHA of the cache action, your workflows will also fail after February 1st.
>
> **What you need to do**:
> We strongly encourage you to update your workflows to begin using a supported version of actions/cache, and upgrade your actions or other products that depend on the @actions/cache package to 4.0.0 or above.

