### PR TITLE
Make _profile preserve docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Make `@_profile` preserve docstrings [#371](https://github.com/litebird/litebird_sim/pull/371)
+
 # Version 0.14.0
 
 -   **Breaking change**: Bug in the 1/f noise generation has been corrected. Previously, the frequency array was miscalculated due to an incorrect factor of 2 in the sample spacing passed to the SciPy function fft.rfftfreq. [#362](https://github.com/litebird/litebird_sim/pull/362). 

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 import codecs
+import functools
 import json
 import logging as log
 import os
@@ -243,6 +244,7 @@ def _profile(function):
     :class:`.Simulation`.
     """
 
+    @functools.wraps(function)
     def profile_wrapper(*args, **kwargs):
         self = args[0]
 


### PR DESCRIPTION
This fixes the problem mentioned here: <https://github.com/litebird/litebird_sim/pull/338#issuecomment-2713719635>.
