### PR TITLE
Fix issue #374

### DIFF
--- a/docs/source/beam_convolution.rst
+++ b/docs/source/beam_convolution.rst
@@ -92,6 +92,7 @@ as demonstrated in the following example:
         blms,
         input_sky_alms_in_galactic=True,
         convolution_params=Convparams,
+        pointings_dtype=np.float32,
     )
 
     for i in range(obs.n_samples):
@@ -304,6 +305,7 @@ For a single-task execution, refer to the following example:
                      beam_alms=blms,
                      convolution_params=Convparams,
                      input_sky_alms_in_galactic=True,
+                     pointings_dtype=np.float32,
                      nthreads = 0)
 
 

--- a/litebird_sim/beam_convolution.py
+++ b/litebird_sim/beam_convolution.py
@@ -195,7 +195,7 @@ def add_convolved_sky(
     input_beam_names: Union[str, None] = None,
     convolution_params: Optional[BeamConvolutionParameters] = None,
     input_sky_alms_in_galactic: bool = True,
-    pointings_dtype=np.float32,
+    pointings_dtype=np.float64,
     nthreads: int = 0,
 ):
     """
@@ -234,7 +234,7 @@ def add_convolved_sky(
         assumed to be in equatorial coordinates.
     pointings_dtype : dtype, optional
         Data type for pointings generated on the fly. If the pointing is passed or
-        already precomputed this parameter is ineffective. Default is `np.float32`.
+        already precomputed this parameter is ineffective. Default is `np.float64`.
     nthreads : int, default=0
         Number of threads to use for convolution. If set to 0, all available CPU cores
         will be used.
@@ -317,7 +317,7 @@ def add_convolved_sky_to_observations(
     input_sky_alms_in_galactic: bool = True,
     convolution_params: Optional[BeamConvolutionParameters] = None,
     component: str = "tod",
-    pointings_dtype=np.float32,
+    pointings_dtype=np.float64,
     nthreads: Union[int, None] = None,
 ):
     """
@@ -349,7 +349,7 @@ def add_convolved_sky_to_observations(
         The name of the TOD component to which the computed data is added.
     pointings_dtype : dtype, optional
         Data type for pointings generated on the fly. If the pointing is passed or
-        already precomputed this parameter is ineffective. Default is `np.float32`.
+        already precomputed this parameter is ineffective. Default is `np.float64`.
     nthreads : int, default=None
         Number of threads to use in the convolution. If None, the function reads from the `OMP_NUM_THREADS`
         environment variable.

--- a/litebird_sim/beam_convolution.py
+++ b/litebird_sim/beam_convolution.py
@@ -195,6 +195,7 @@ def add_convolved_sky(
     input_beam_names: Union[str, None] = None,
     convolution_params: Optional[BeamConvolutionParameters] = None,
     input_sky_alms_in_galactic: bool = True,
+    pointings_dtype=np.float32,
     nthreads: int = 0,
 ):
     """
@@ -231,6 +232,9 @@ def add_convolved_sky(
     input_sky_alms_in_galactic : bool, default=True
         Whether the input sky maps are provided in Galactic coordinates. If False, they are
         assumed to be in equatorial coordinates.
+    pointings_dtype : dtype, optional
+        Data type for pointings generated on the fly. If the pointing is passed or
+        already precomputed this parameter is ineffective. Default is `np.float32`.
     nthreads : int, default=0
         Number of threads to use for convolution. If set to 0, all available CPU cores
         will be used.
@@ -264,7 +268,7 @@ def add_convolved_sky(
             curr_pointings_det = pointings[detector_idx, :, :]
         else:
             curr_pointings_det, hwp_angle = pointings(
-                detector_idx, pointings_dtype=tod.dtype
+                detector_idx, pointings_dtype=pointings_dtype
             )
 
         if input_sky_alms_in_galactic:
@@ -313,6 +317,7 @@ def add_convolved_sky_to_observations(
     input_sky_alms_in_galactic: bool = True,
     convolution_params: Optional[BeamConvolutionParameters] = None,
     component: str = "tod",
+    pointings_dtype=np.float32,
     nthreads: Union[int, None] = None,
 ):
     """
@@ -342,13 +347,17 @@ def add_convolved_sky_to_observations(
         Parameters controlling the beam convolution, including resolution limits and numerical precision.
     component : str, default="tod"
         The name of the TOD component to which the computed data is added.
+    pointings_dtype : dtype, optional
+        Data type for pointings generated on the fly. If the pointing is passed or
+        already precomputed this parameter is ineffective. Default is `np.float32`.
     nthreads : int, default=None
         Number of threads to use in the convolution. If None, the function reads from the `OMP_NUM_THREADS`
         environment variable.
 
     Notes
     -----
-    - If `pointings` is not provided, it is inferred from the `Observation` objects.
+    - If `pointings` is not provided, it is inferred from the `Observation` objects. If the pointing is passed
+        or already precomputed this parameter is ineffective. Default is `np.float32`.
     - The function determines the correct sky and beam harmonics from the detector names or channels.
     - Calls `add_convolved_sky` to process the TOD for all detectors.
     """
@@ -441,9 +450,7 @@ def add_convolved_sky_to_observations(
                 hwp_angle = getattr(
                     cur_obs,
                     "hwp_angle",
-                    cur_obs.get_pointings(
-                        pointings_dtype=getattr(cur_obs, component).dtype
-                    )[1],
+                    cur_obs.get_pointings(pointings_dtype=pointings_dtype)[1],
                 )
             else:
                 assert all(
@@ -472,5 +479,6 @@ def add_convolved_sky_to_observations(
             input_beam_names=input_beam_names,
             convolution_params=convolution_params,
             input_sky_alms_in_galactic=input_sky_alms_in_galactic,
+            pointings_dtype=pointings_dtype,
             nthreads=nthreads,
         )

--- a/litebird_sim/dipole.py
+++ b/litebird_sim/dipole.py
@@ -197,7 +197,7 @@ def add_dipole(
     # lbs.FreqChannelInfo.from_imo(url=…, imo=imo).bandcenter_ghz
     # using as url f"/releases/v1.0/satellite/{telescope}/{channel}/channel_info"
     dipole_type: DipoleType,
-    pointings_dtype=np.float32,
+    pointings_dtype=np.float64,
 ):
     """
     Add the CMB dipole contribution to time-ordered data (TOD).
@@ -241,7 +241,7 @@ def add_dipole(
 
     pointings_dtype : dtype, optional
         Data type for pointings generated on the fly. If the pointing is passed or
-        already precomputed this parameter is ineffective. Default is `np.float32`.
+        already precomputed this parameter is ineffective. Default is `np.float64`.
 
     Notes
     -----
@@ -308,7 +308,7 @@ def add_dipole_to_observations(
         np.ndarray, None
     ] = None,  # e.g. central frequency of channel from
     component: str = "tod",
-    pointings_dtype=np.float32,
+    pointings_dtype=np.float64,
 ):
     """
     Add the CMB dipole signal to the time-ordered data (TOD) stored in one or more
@@ -353,7 +353,7 @@ def add_dipole_to_observations(
 
     pointings_dtype : dtype, optional
         Data type for pointings generated on the fly. If the pointing is passed or
-        already precomputed this parameter is ineffective. Default is `np.float32`.
+        already precomputed this parameter is ineffective. Default is `np.float64`.
 
     Notes
     -----

--- a/litebird_sim/dipole.py
+++ b/litebird_sim/dipole.py
@@ -197,7 +197,7 @@ def add_dipole(
     # lbs.FreqChannelInfo.from_imo(url=…, imo=imo).bandcenter_ghz
     # using as url f"/releases/v1.0/satellite/{telescope}/{channel}/channel_info"
     dipole_type: DipoleType,
-    pointings_dtype = np.float32,
+    pointings_dtype=np.float32,
 ):
     """
     Add the CMB dipole contribution to time-ordered data (TOD).
@@ -278,10 +278,9 @@ def add_dipole(
         if type(pointings) is np.ndarray:
             theta_phi_det = pointings[detector_idx, :, :]
         else:
-            theta_phi_det = pointings(
-                detector_idx,
-                pointings_dtype=pointings_dtype
-            )[0][:, 0:2]
+            theta_phi_det = pointings(detector_idx, pointings_dtype=pointings_dtype)[0][
+                :, 0:2
+            ]
 
         add_dipole_for_one_detector(
             tod_det=tod[detector_idx],

--- a/litebird_sim/dipole.py
+++ b/litebird_sim/dipole.py
@@ -239,6 +239,10 @@ def add_dipole(
     dipole_type : DipoleType
         Specifies the method used to compute the dipole contribution.
 
+    pointings_dtype : dtype, optional
+        Data type for pointings generated on the fly. If the pointing is passed or
+        already precomputed this parameter is ineffective. Default is `np.float32`.
+
     Notes
     -----
     - The dipole contribution is computed individually for each detector using
@@ -347,10 +351,15 @@ def add_dipole_to_observations(
         stored. Default is `"tod"`, but a different field (e.g., `"dipole_tod"`) can
         be specified.
 
+    pointings_dtype : dtype, optional
+        Data type for pointings generated on the fly. If the pointing is passed or
+        already precomputed this parameter is ineffective. Default is `np.float32`.
+
     Notes
     -----
     - If `pointings` is not provided, the function will extract pointing matrices from
-      the `Observation` objects.
+      the `Observation` objects. If the pointing is generated on the fly pointings_dtype
+      specifies its type.
     - The spacecraft velocity is interpolated over the timestamps of each observation.
 
     Example

--- a/litebird_sim/dipole.py
+++ b/litebird_sim/dipole.py
@@ -197,6 +197,7 @@ def add_dipole(
     # lbs.FreqChannelInfo.from_imo(url=…, imo=imo).bandcenter_ghz
     # using as url f"/releases/v1.0/satellite/{telescope}/{channel}/channel_info"
     dipole_type: DipoleType,
+    pointings_dtype = np.float32,
 ):
     """
     Add the CMB dipole contribution to time-ordered data (TOD).
@@ -279,7 +280,7 @@ def add_dipole(
         else:
             theta_phi_det = pointings(
                 detector_idx,
-                pointings_dtype=tod.dtype,
+                pointings_dtype=pointings_dtype
             )[0][:, 0:2]
 
         add_dipole_for_one_detector(
@@ -304,6 +305,7 @@ def add_dipole_to_observations(
         np.ndarray, None
     ] = None,  # e.g. central frequency of channel from
     component: str = "tod",
+    pointings_dtype=np.float32,
 ):
     """
     Add the CMB dipole signal to the time-ordered data (TOD) stored in one or more
@@ -429,4 +431,5 @@ def add_dipole_to_observations(
             t_cmb_k=t_cmb_k,
             frequency_ghz=frequency_ghz,
             dipole_type=dipole_type,
+            pointings_dtype=pointings_dtype,
         )

--- a/litebird_sim/io.py
+++ b/litebird_sim/io.py
@@ -374,7 +374,7 @@ def write_list_of_observations(
     observations: Union[Observation, List[Observation]],
     path: Union[str, Path],
     tod_dtype=np.float32,
-    pointings_dtype=np.float32,
+    pointings_dtype=np.float64,
     file_name_mask: str = __OBSERVATION_FILE_NAME_MASK,
     custom_placeholders: Optional[List[Dict[str, Any]]] = None,
     start_index: int = 0,

--- a/litebird_sim/mapmaking/binner.py
+++ b/litebird_sim/mapmaking/binner.py
@@ -197,7 +197,7 @@ def _build_nobs_matrix(
     tm_list: List[npt.ArrayLike],
     output_coordinate_system: CoordinateSystem,
     components: List[str],
-    pointings_dtype=np.float32,
+    pointings_dtype=np.float64,
 ) -> npt.ArrayLike:
     hpx = Healpix_Base(nside, "RING")
     n_pix = nside_to_npix(nside)
@@ -281,7 +281,7 @@ def make_binned_map(
     components: List[str] = None,
     detector_split: str = "full",
     time_split: str = "full",
-    pointings_dtype=np.float32,
+    pointings_dtype=np.float64,
 ) -> BinnerResult:
     """Bin Map-maker
 
@@ -315,7 +315,7 @@ def make_binned_map(
         time_split (str): select the time split to use in the map-making.
         pointings_dtype(dtype): data type for pointings generated on the fly. If
             the pointing is passed or already precomputed this parameter is
-            ineffective. Default is `np.float32`.
+            ineffective. Default is `np.float64`.
 
     Returns:
         An instance of the class :class:`.MapMakerResult`. If the observations are

--- a/litebird_sim/mapmaking/binner.py
+++ b/litebird_sim/mapmaking/binner.py
@@ -313,6 +313,9 @@ def make_binned_map(
             :class:`.Observation` object
         detector_split (str): select the detector split to use in the map-making
         time_split (str): select the time split to use in the map-making.
+        pointings_dtype(dtype): data type for pointings generated on the fly. If
+            the pointing is passed or already precomputed this parameter is
+            ineffective. Default is `np.float32`.
 
     Returns:
         An instance of the class :class:`.MapMakerResult`. If the observations are

--- a/litebird_sim/mapmaking/binner.py
+++ b/litebird_sim/mapmaking/binner.py
@@ -197,7 +197,7 @@ def _build_nobs_matrix(
     tm_list: List[npt.ArrayLike],
     output_coordinate_system: CoordinateSystem,
     components: List[str],
-    pointings_dtype = np.float32,
+    pointings_dtype=np.float32,
 ) -> npt.ArrayLike:
     hpx = Healpix_Base(nside, "RING")
     n_pix = nside_to_npix(nside)
@@ -236,10 +236,10 @@ def _build_nobs_matrix(
         first_component = getattr(cur_obs, components[0])
         for idx, cur_component_name in enumerate(components):
             cur_component = getattr(cur_obs, cur_component_name)
-            assert (
-                cur_component.shape == first_component.shape
-            ), 'The two TODs "{}" and "{}" do not have a matching shape'.format(
-                components[0], cur_component_name
+            assert cur_component.shape == first_component.shape, (
+                'The two TODs "{}" and "{}" do not have a matching shape'.format(
+                    components[0], cur_component_name
+                )
             )
             _accumulate_samples_and_build_nobs_matrix(
                 cur_component,
@@ -281,7 +281,7 @@ def make_binned_map(
     components: List[str] = None,
     detector_split: str = "full",
     time_split: str = "full",
-    pointings_dtype = np.float32,
+    pointings_dtype=np.float32,
 ) -> BinnerResult:
     """Bin Map-maker
 

--- a/litebird_sim/mapmaking/binner.py
+++ b/litebird_sim/mapmaking/binner.py
@@ -236,10 +236,10 @@ def _build_nobs_matrix(
         first_component = getattr(cur_obs, components[0])
         for idx, cur_component_name in enumerate(components):
             cur_component = getattr(cur_obs, cur_component_name)
-            assert cur_component.shape == first_component.shape, (
-                'The two TODs "{}" and "{}" do not have a matching shape'.format(
-                    components[0], cur_component_name
-                )
+            assert (
+                cur_component.shape == first_component.shape
+            ), 'The two TODs "{}" and "{}" do not have a matching shape'.format(
+                components[0], cur_component_name
             )
             _accumulate_samples_and_build_nobs_matrix(
                 cur_component,

--- a/litebird_sim/mapmaking/binner.py
+++ b/litebird_sim/mapmaking/binner.py
@@ -197,6 +197,7 @@ def _build_nobs_matrix(
     tm_list: List[npt.ArrayLike],
     output_coordinate_system: CoordinateSystem,
     components: List[str],
+    pointings_dtype = np.float32,
 ) -> npt.ArrayLike:
     hpx = Healpix_Base(nside, "RING")
     n_pix = nside_to_npix(nside)
@@ -229,6 +230,7 @@ def _build_nobs_matrix(
             num_of_samples=cur_obs.n_samples,
             hwp_angle=hwp_angle,
             output_coordinate_system=output_coordinate_system,
+            pointings_dtype=pointings_dtype,
         )
 
         first_component = getattr(cur_obs, components[0])
@@ -279,6 +281,7 @@ def make_binned_map(
     components: List[str] = None,
     detector_split: str = "full",
     time_split: str = "full",
+    pointings_dtype = np.float32,
 ) -> BinnerResult:
     """Bin Map-maker
 
@@ -336,6 +339,7 @@ def make_binned_map(
         tm_list=time_mask_list,
         output_coordinate_system=output_coordinate_system,
         components=components,
+        pointings_dtype=pointings_dtype,
     )
 
     rhs = _extract_map_and_fill_info(nobs_matrix)

--- a/litebird_sim/mapmaking/common.py
+++ b/litebird_sim/mapmaking/common.py
@@ -110,12 +110,12 @@ def get_map_making_weights(
 
     if check:
         # Check that there are no weird weights
-        assert np.all(np.isfinite(weights)), (
-            f"Not all the detectors' weights are finite numbers: {weights}"
-        )
-        assert np.all(weights > 0.0), (
-            f"Not all the detectors' weights are positive: {weights}"
-        )
+        assert np.all(
+            np.isfinite(weights)
+        ), f"Not all the detectors' weights are finite numbers: {weights}"
+        assert np.all(
+            weights > 0.0
+        ), f"Not all the detectors' weights are positive: {weights}"
 
     return weights
 

--- a/litebird_sim/mapmaking/common.py
+++ b/litebird_sim/mapmaking/common.py
@@ -183,7 +183,7 @@ def _compute_pixel_indices(
     num_of_samples: int,
     hwp_angle: Union[npt.ArrayLike, None],
     output_coordinate_system: CoordinateSystem,
-    pointings_dtype=np.float32,
+    pointings_dtype=np.float64,
 ) -> Tuple[npt.NDArray, npt.NDArray]:
     """Compute the index of each pixel and its attack angle
 

--- a/litebird_sim/mapmaking/common.py
+++ b/litebird_sim/mapmaking/common.py
@@ -183,6 +183,7 @@ def _compute_pixel_indices(
     num_of_samples: int,
     hwp_angle: Union[npt.ArrayLike, None],
     output_coordinate_system: CoordinateSystem,
+    pointings_dtype=np.float32,
 ) -> Tuple[npt.NDArray, npt.NDArray]:
     """Compute the index of each pixel and its attack angle
 
@@ -207,7 +208,9 @@ def _compute_pixel_indices(
         if type(pointings) is np.ndarray:
             curr_pointings_det = pointings[idet, :, :]
         else:
-            curr_pointings_det, hwp_angle = pointings(idet)
+            curr_pointings_det, hwp_angle = pointings(
+                idet,
+                pointings_dtype=pointings_dtype)
 
         if output_coordinate_system == CoordinateSystem.Galactic:
             curr_pointings_det = rotate_coordinates_e2g(curr_pointings_det)

--- a/litebird_sim/mapmaking/common.py
+++ b/litebird_sim/mapmaking/common.py
@@ -110,12 +110,12 @@ def get_map_making_weights(
 
     if check:
         # Check that there are no weird weights
-        assert np.all(
-            np.isfinite(weights)
-        ), f"Not all the detectors' weights are finite numbers: {weights}"
-        assert np.all(
-            weights > 0.0
-        ), f"Not all the detectors' weights are positive: {weights}"
+        assert np.all(np.isfinite(weights)), (
+            f"Not all the detectors' weights are finite numbers: {weights}"
+        )
+        assert np.all(weights > 0.0), (
+            f"Not all the detectors' weights are positive: {weights}"
+        )
 
     return weights
 
@@ -209,8 +209,8 @@ def _compute_pixel_indices(
             curr_pointings_det = pointings[idet, :, :]
         else:
             curr_pointings_det, hwp_angle = pointings(
-                idet,
-                pointings_dtype=pointings_dtype)
+                idet, pointings_dtype=pointings_dtype
+            )
 
         if output_coordinate_system == CoordinateSystem.Galactic:
             curr_pointings_det = rotate_coordinates_e2g(curr_pointings_det)

--- a/litebird_sim/mapmaking/destriper.py
+++ b/litebird_sim/mapmaking/destriper.py
@@ -446,7 +446,7 @@ def _store_pixel_idx_and_pol_angle_in_obs(
     ptg_list: Union[List[npt.ArrayLike], List[Callable]],
     hwp: Union[HWP, None],
     output_coordinate_system: CoordinateSystem,
-    pointings_dtype=np.float32,
+    pointings_dtype=np.float64,
 ):
     for cur_obs, cur_ptg in zip(obs_list, ptg_list):
         cur_obs.destriper_weights = get_map_making_weights(cur_obs, check=True)
@@ -1473,7 +1473,7 @@ def make_destriped_map(
     recycled_convergence: bool = False,
     callback: Any = destriper_log_callback,
     callback_kwargs: Optional[Dict[Any, Any]] = None,
-    pointings_dtype=np.float32,
+    pointings_dtype=np.float64,
 ) -> DestriperResult:
     """
     Applies the destriping algorithm to produce a map out from a TOD
@@ -1568,7 +1568,7 @@ def make_destriped_map(
        passed to the `callback` function
     :param pointings_dtype(dtype): data type for pointings generated on
         the fly. If the pointing is passed or already precomputed this
-        parameter is ineffective. Default is `np.float32`.
+        parameter is ineffective. Default is `np.float64`.
 
     :return: an instance of the :class:`.DestriperResult`
        containing the destriped map and other useful information

--- a/litebird_sim/mapmaking/destriper.py
+++ b/litebird_sim/mapmaking/destriper.py
@@ -446,6 +446,7 @@ def _store_pixel_idx_and_pol_angle_in_obs(
     ptg_list: Union[List[npt.ArrayLike], List[Callable]],
     hwp: Union[HWP, None],
     output_coordinate_system: CoordinateSystem,
+    pointings_dtype = np.float32,
 ):
     for cur_obs, cur_ptg in zip(obs_list, ptg_list):
         cur_obs.destriper_weights = get_map_making_weights(cur_obs, check=True)
@@ -474,6 +475,7 @@ def _store_pixel_idx_and_pol_angle_in_obs(
             num_of_samples=cur_obs.n_samples,
             hwp_angle=hwp_angle,
             output_coordinate_system=output_coordinate_system,
+            pointings_dtype=pointings_dtype,
         )
 
 
@@ -1471,6 +1473,7 @@ def make_destriped_map(
     recycled_convergence: bool = False,
     callback: Any = destriper_log_callback,
     callback_kwargs: Optional[Dict[Any, Any]] = None,
+    pointings_dtype = np.float32,
 ) -> DestriperResult:
     """
     Applies the destriping algorithm to produce a map out from a TOD
@@ -1589,6 +1592,7 @@ def make_destriped_map(
         ptg_list=ptg_list,
         hwp=hwp,
         output_coordinate_system=params.output_coordinate_system,
+        pointings_dtype=pointings_dtype,
     )
 
     if len(components) > 1:

--- a/litebird_sim/mapmaking/destriper.py
+++ b/litebird_sim/mapmaking/destriper.py
@@ -68,9 +68,9 @@ def _split_items_into_n_segments(n: int, num_of_segments: int) -> List[int]:
         [2 3 2 3]
     """
     assert num_of_segments > 0, f"num_of_segments={num_of_segments} is not positive"
-    assert (
-        n >= num_of_segments
-    ), f"n={n} is smaller than num_of_segments={num_of_segments}"
+    assert n >= num_of_segments, (
+        f"n={n} is smaller than num_of_segments={num_of_segments}"
+    )
 
     start_positions = np.array(
         [int(i * n / num_of_segments) for i in range(num_of_segments + 1)],
@@ -446,7 +446,7 @@ def _store_pixel_idx_and_pol_angle_in_obs(
     ptg_list: Union[List[npt.ArrayLike], List[Callable]],
     hwp: Union[HWP, None],
     output_coordinate_system: CoordinateSystem,
-    pointings_dtype = np.float32,
+    pointings_dtype=np.float32,
 ):
     for cur_obs, cur_ptg in zip(obs_list, ptg_list):
         cur_obs.destriper_weights = get_map_making_weights(cur_obs, check=True)
@@ -1473,7 +1473,7 @@ def make_destriped_map(
     recycled_convergence: bool = False,
     callback: Any = destriper_log_callback,
     callback_kwargs: Optional[Dict[Any, Any]] = None,
-    pointings_dtype = np.float32,
+    pointings_dtype=np.float32,
 ) -> DestriperResult:
     """
     Applies the destriping algorithm to produce a map out from a TOD

--- a/litebird_sim/mapmaking/destriper.py
+++ b/litebird_sim/mapmaking/destriper.py
@@ -1566,6 +1566,10 @@ def make_destriped_map(
        want (see above for an example).
     :param callback_kwargs: additional keyword arguments to be
        passed to the `callback` function
+    :param pointings_dtype(dtype): data type for pointings generated on
+        the fly. If the pointing is passed or already precomputed this
+        parameter is ineffective. Default is `np.float32`.
+
     :return: an instance of the :class:`.DestriperResult`
        containing the destriped map and other useful information
     """

--- a/litebird_sim/mapmaking/destriper.py
+++ b/litebird_sim/mapmaking/destriper.py
@@ -68,9 +68,9 @@ def _split_items_into_n_segments(n: int, num_of_segments: int) -> List[int]:
         [2 3 2 3]
     """
     assert num_of_segments > 0, f"num_of_segments={num_of_segments} is not positive"
-    assert n >= num_of_segments, (
-        f"n={n} is smaller than num_of_segments={num_of_segments}"
-    )
+    assert (
+        n >= num_of_segments
+    ), f"n={n} is smaller than num_of_segments={num_of_segments}"
 
     start_positions = np.array(
         [int(i * n / num_of_segments) for i in range(num_of_segments + 1)],

--- a/litebird_sim/observations.py
+++ b/litebird_sim/observations.py
@@ -793,7 +793,7 @@ class Observation:
         detector_idx: Union[int, List[int], str] = "all",
         pointing_buffer: Optional[npt.NDArray] = None,
         hwp_buffer: Optional[npt.NDArray] = None,
-        pointings_dtype=np.float32,
+        pointings_dtype=np.float64,
     ) -> tuple[npt.NDArray, Optional[npt.NDArray]]:
         """
         Compute the pointings for one or more detectors in this observation

--- a/litebird_sim/pointings.py
+++ b/litebird_sim/pointings.py
@@ -81,7 +81,7 @@ class PointingProvider:
         nsamples: int,
         pointing_buffer: Optional[npt.NDArray] = None,
         hwp_buffer: Optional[npt.NDArray] = None,
-        pointings_dtype=np.float32,
+        pointings_dtype=np.float64,
     ) -> Union[npt.NDArray, Optional[npt.NDArray]]:
         """
 

--- a/litebird_sim/pointings_in_obs.py
+++ b/litebird_sim/pointings_in_obs.py
@@ -57,7 +57,7 @@ def prepare_pointings(
 
 def precompute_pointings(
     observations: Union[Observation, List[Observation]],
-    pointings_dtype=np.float32,
+    pointings_dtype=np.float64,
 ) -> None:
     """Precompute all the pointings for a set of observations
 

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -112,6 +112,7 @@ def scan_map(
     input_names: Union[str, None] = None,
     input_map_in_galactic: bool = True,
     interpolation: Union[str, None] = "",
+    pointings_dtype = np.float32,
 ):
     """
     Scan a sky map and fill time-ordered data (TOD) based on detector observations.
@@ -190,7 +191,7 @@ def scan_map(
             curr_pointings_det = pointings[detector_idx, :, :]
         else:
             curr_pointings_det, hwp_angle = pointings(
-                detector_idx, pointings_dtype=tod.dtype
+                detector_idx, pointings_dtype=pointings_dtype
             )
         if input_map_in_galactic:
             curr_pointings_det = rotate_coordinates_e2g(curr_pointings_det)
@@ -274,6 +275,7 @@ def scan_map_in_observations(
     input_map_in_galactic: bool = True,
     component: str = "tod",
     interpolation: Optional[str] = "",
+    pointings_dtype = np.float32,
 ):
     """
 
@@ -448,4 +450,5 @@ def scan_map_in_observations(
             input_names=input_names,
             input_map_in_galactic=input_map_in_galactic,
             interpolation=interpolation,
+            pointings_dtype=pointings_dtype,
         )

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -133,31 +133,44 @@ def scan_map(
     tod : np.ndarray
         Time-ordered data (TOD) array of shape (n_detectors, n_samples) that will be filled
         with the simulated sky signal.
+
     pointings : np.ndarray or callable
         Pointing information for each detector. If an array, it should have shape
         (n_detectors, n_samples, 2), where the last dimension contains (theta, phi) in radians.
         If a callable, it should return pointing data when passed a detector index.
+
     maps : dict of str -> np.ndarray
         Dictionary containing Stokes parameter maps (T, Q, U) in Healpix format. The keys
         correspond to different sky components.
+
     pol_angle_detectors : np.ndarray or None, default=None
         Polarization angles of detectors in radians. If None, all angles are set to zero.
+
     pol_eff_detectors : np.ndarray or None, default=None
         Polarization efficiency of detectors. If None, all detectors have unit efficiency.
+
     hwp_angle : np.ndarray or None, default=None
         Half-wave plate (HWP) angles for each detector in radians. If None, HWP effects are
         ignored.
+
     mueller_hwp : np.ndarray or None, default=None
         Mueller matrices for the HWP. If None, a standard polarization response is used.
+
     input_names : str or None, default=None
         Names of the sky maps to use for each detector. If None, all detectors use the same map.
+
     input_map_in_galactic : bool, default=True
         Whether the input sky maps are provided in Galactic coordinates. If False, they are
         assumed to be in Ecliptic coordinates.
+
     interpolation : str or None, default=""
         Method for extracting values from the maps:
         - "" (default): Nearest-neighbor interpolation.
         - "linear": Linear interpolation using Healpix.
+
+    pointings_dtype : dtype, optional
+        Data type for pointings generated on the fly. If the pointing is passed or
+        already precomputed this parameter is ineffective. Default is `np.float32`.
 
     Raises
     ------
@@ -316,25 +329,35 @@ def scan_map_in_observations(
     observations : Observation or list of Observation
         One or more `Observation` objects containing detector names, pointings,
         and TOD data, to which the computed sky signal will be added.
+
     maps : np.ndarray or dict of str -> np.ndarray
         Sky maps containing Stokes parameters (T, Q, U). If a dictionary, keys
         should match detector or channel names, and values should be arrays of shape (3, NPIX).
         If a single array is provided, the same map is used for all detectors.
+
     pointings : np.ndarray or list of np.ndarray, optional
         Pointing matrices associated with the observations. If None, the function
         extracts pointing information from the `Observation` objects.
+
     hwp : HWP, optional
         Half-wave plate (HWP) model. If None, HWP effects are ignored unless
         the `Observation` object contains HWP data.
+
     input_map_in_galactic : bool, default=True
         Whether the input sky maps are provided in Galactic coordinates. If False, they
         are assumed to be in Ecliptic coordinates.
+
     component : str, default="tod"
         The TOD component in the `Observation` object where the computed signal will be stored.
+
     interpolation : str, optional, default=""
         Method for extracting values from the sky maps:
         - "" (default): Nearest-neighbor interpolation.
         - "linear": Linear interpolation using Healpix.
+
+    pointings_dtype : dtype, optional
+        Data type for pointings generated on the fly. If the pointing is passed or
+        already precomputed this parameter is ineffective. Default is `np.float32`.
 
     Raises
     ------
@@ -352,6 +375,7 @@ def scan_map_in_observations(
     - If `maps` is a dictionary, its `Coordinates` key (if present) must match
       `input_map_in_galactic`, otherwise a warning is issued.
     - If `pointings` is None, the function attempts to extract them from `Observation` objects.
+      If the pointing is generated on the fly pointings_dtype specifies its type.
     - If an HWP model is provided, the function computes HWP angles and applies the
       corresponding Mueller matrices.
     - This function supports both single observations and lists of observations,
@@ -426,7 +450,9 @@ def scan_map_in_observations(
                 if hasattr(cur_obs, "hwp_angle"):
                     hwp_angle = cur_obs.hwp_angle
                 else:
-                    hwp_angle = cur_obs.get_pointings()[1]
+                    hwp_angle = cur_obs.get_pointings(pointings_dtype=pointings_dtype)[
+                        1
+                    ]
             else:
                 assert all(m is None for m in cur_obs.mueller_hwp), (
                     "Detectors have been initialized with a mueller_hwp,"

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -112,7 +112,7 @@ def scan_map(
     input_names: Union[str, None] = None,
     input_map_in_galactic: bool = True,
     interpolation: Union[str, None] = "",
-    pointings_dtype = np.float32,
+    pointings_dtype=np.float32,
 ):
     """
     Scan a sky map and fill time-ordered data (TOD) based on detector observations.
@@ -275,7 +275,7 @@ def scan_map_in_observations(
     input_map_in_galactic: bool = True,
     component: str = "tod",
     interpolation: Optional[str] = "",
-    pointings_dtype = np.float32,
+    pointings_dtype=np.float32,
 ):
     """
 

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -112,7 +112,7 @@ def scan_map(
     input_names: Union[str, None] = None,
     input_map_in_galactic: bool = True,
     interpolation: Union[str, None] = "",
-    pointings_dtype=np.float32,
+    pointings_dtype=np.float64,
 ):
     """
     Scan a sky map and fill time-ordered data (TOD) based on detector observations.
@@ -170,7 +170,7 @@ def scan_map(
 
     pointings_dtype : dtype, optional
         Data type for pointings generated on the fly. If the pointing is passed or
-        already precomputed this parameter is ineffective. Default is `np.float32`.
+        already precomputed this parameter is ineffective. Default is `np.float64`.
 
     Raises
     ------
@@ -288,7 +288,7 @@ def scan_map_in_observations(
     input_map_in_galactic: bool = True,
     component: str = "tod",
     interpolation: Optional[str] = "",
-    pointings_dtype=np.float32,
+    pointings_dtype=np.float64,
 ):
     """
 
@@ -357,7 +357,7 @@ def scan_map_in_observations(
 
     pointings_dtype : dtype, optional
         Data type for pointings generated on the fly. If the pointing is passed or
-        already precomputed this parameter is ineffective. Default is `np.float32`.
+        already precomputed this parameter is ineffective. Default is `np.float64`.
 
     Raises
     ------

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -1348,7 +1348,7 @@ class Simulation:
                 memory_occupation=int(memory_occupation),
             )
 
-    def precompute_pointings(self, pointings_dtype=np.float32) -> None:
+    def precompute_pointings(self, pointings_dtype=np.float64) -> None:
         """Compute all the pointings for all observations and save them
 
         Save the pointing matrix of each :class:`.Observation` object in this simulation
@@ -1398,7 +1398,7 @@ class Simulation:
         t_cmb_k: float = constants.T_CMB_K,
         dipole_type: DipoleType = DipoleType.TOTAL_FROM_LIN_T,
         component: str = "tod",
-        pointings_dtype=np.float32,
+        pointings_dtype=np.float64,
         append_to_report: bool = True,
     ):
         """
@@ -1448,7 +1448,7 @@ class Simulation:
         input_map_in_galactic: bool = True,
         component: str = "tod",
         interpolation: Union[str, None] = "",
-        pointings_dtype=np.float32,
+        pointings_dtype=np.float64,
         append_to_report: bool = True,
     ):
         """
@@ -1568,7 +1568,7 @@ class Simulation:
         input_sky_alms_in_galactic: bool = True,
         convolution_params: Optional[BeamConvolutionParameters] = None,
         component: str = "tod",
-        pointings_dtype=np.float32,
+        pointings_dtype=np.float64,
         append_to_report: bool = True,
         nthreads: Union[int, None] = None,
     ):
@@ -1757,7 +1757,7 @@ class Simulation:
         time_splits: Union[str, List[str]] = "full",
         write_to_disk: bool = True,
         include_inv_covariance: bool = False,
-        pointings_dtype=np.float32,
+        pointings_dtype=np.float64,
         append_to_report: bool = True,
     ) -> Union[List[str], dict[str, BinnerResult]]:
         """
@@ -1843,7 +1843,7 @@ class Simulation:
         components: Optional[List[str]] = None,
         detector_split: str = "full",
         time_split: str = "full",
-        pointings_dtype=np.float32,
+        pointings_dtype=np.float64,
         append_to_report: bool = True,
     ) -> BinnerResult:
         """
@@ -1908,7 +1908,7 @@ class Simulation:
         callback_kwargs: Optional[Dict[Any, Any]] = None,
         write_to_disk: bool = True,
         recycle_baselines: bool = False,
-        pointings_dtype=np.float32,
+        pointings_dtype=np.float64,
         append_to_report: bool = True,
     ) -> Union[List[str], dict[str, DestriperResult]]:
         """
@@ -2025,7 +2025,7 @@ class Simulation:
         keep_pol_angle_rad: bool = False,
         callback: Any = destriper_log_callback,
         callback_kwargs: Optional[Dict[Any, Any]] = None,
-        pointings_dtype=np.float32,
+        pointings_dtype=np.float64,
         append_to_report: bool = True,
     ) -> DestriperResult:
         """

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -1398,6 +1398,7 @@ class Simulation:
         t_cmb_k: float = constants.T_CMB_K,
         dipole_type: DipoleType = DipoleType.TOTAL_FROM_LIN_T,
         component: str = "tod",
+        pointings_dtype=np.float32,
         append_to_report: bool = True,
     ):
         """
@@ -1419,6 +1420,7 @@ class Simulation:
             t_cmb_k=t_cmb_k,
             dipole_type=dipole_type,
             component=component,
+            pointings_dtype=pointings_dtype,
         )
 
         if append_to_report and MPI_COMM_WORLD.rank == 0:
@@ -1446,6 +1448,7 @@ class Simulation:
         input_map_in_galactic: bool = True,
         component: str = "tod",
         interpolation: Union[str, None] = "",
+        pointings_dtype=np.float32,
         append_to_report: bool = True,
     ):
         """
@@ -1466,6 +1469,7 @@ class Simulation:
             input_map_in_galactic=input_map_in_galactic,
             component=component,
             interpolation=interpolation,
+            pointings_dtype=pointings_dtype,
         )
 
         if append_to_report and MPI_COMM_WORLD.rank == 0:
@@ -1564,6 +1568,7 @@ class Simulation:
         input_sky_alms_in_galactic: bool = True,
         convolution_params: Optional[BeamConvolutionParameters] = None,
         component: str = "tod",
+        pointings_dtype=np.float32,
         append_to_report: bool = True,
         nthreads: Union[int, None] = None,
     ):
@@ -1586,6 +1591,7 @@ class Simulation:
             input_sky_alms_in_galactic=input_sky_alms_in_galactic,
             component=component,
             convolution_params=convolution_params,
+            pointings_dtype=pointings_dtype,
             nthreads=nthreads,
         )
 
@@ -1751,6 +1757,7 @@ class Simulation:
         time_splits: Union[str, List[str]] = "full",
         write_to_disk: bool = True,
         include_inv_covariance: bool = False,
+        pointings_dtype=np.float32,
         append_to_report: bool = True,
     ) -> Union[List[str], dict[str, BinnerResult]]:
         """
@@ -1791,6 +1798,7 @@ class Simulation:
                         components=components,
                         detector_split=ds,
                         time_split=ts,
+                        pointings_dtype=pointings_dtype,
                     )
                     file = f"binned_map_DET{ds}_TIME{ts}.fits"
                     names = ["I", "Q", "U"]
@@ -1823,6 +1831,7 @@ class Simulation:
                         components=components,
                         detector_split=ds,
                         time_split=ts,
+                        pointings_dtype=pointings_dtype,
                     )
         return binned_maps
 
@@ -1834,6 +1843,7 @@ class Simulation:
         components: Optional[List[str]] = None,
         detector_split: str = "full",
         time_split: str = "full",
+        pointings_dtype=np.float32,
         append_to_report: bool = True,
     ) -> BinnerResult:
         """
@@ -1864,6 +1874,7 @@ class Simulation:
             components=components,
             detector_split=detector_split,
             time_split=time_split,
+            pointings_dtype=pointings_dtype,
         )
 
     def _impose_and_check_full_split(self, detector_splits, time_splits):

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -1908,6 +1908,7 @@ class Simulation:
         callback_kwargs: Optional[Dict[Any, Any]] = None,
         write_to_disk: bool = True,
         recycle_baselines: bool = False,
+        pointings_dtype=np.float32,
         append_to_report: bool = True,
     ) -> Union[List[str], dict[str, DestriperResult]]:
         """
@@ -1950,6 +1951,7 @@ class Simulation:
                         keep_pol_angle_rad=keep_pol_angle_rad,
                         callback=callback,
                         callback_kwargs=callback_kwargs,
+                        pointings_dtype=pointings_dtype,
                     )
                     if recycle_baselines and f"{ds}_{ts}" == "full_full":
                         baselines = result.baselines
@@ -1994,6 +1996,7 @@ class Simulation:
                         keep_pol_angle_rad=keep_pol_angle_rad,
                         callback=callback,
                         callback_kwargs=callback_kwargs,
+                        pointings_dtype=pointings_dtype,
                     )
                     if recycle_baselines and f"{ds}_{ts}" == "full_full":
                         baselines = destriped_maps[f"{ds}_{ts}"].baselines
@@ -2022,6 +2025,7 @@ class Simulation:
         keep_pol_angle_rad: bool = False,
         callback: Any = destriper_log_callback,
         callback_kwargs: Optional[Dict[Any, Any]] = None,
+        pointings_dtype=np.float32,
         append_to_report: bool = True,
     ) -> DestriperResult:
         """
@@ -2050,6 +2054,7 @@ class Simulation:
             keep_pol_angle_rad=keep_pol_angle_rad,
             callback=callback,
             callback_kwargs=callback_kwargs,
+            pointings_dtype=pointings_dtype,
         )
 
         if append_to_report:

--- a/notebooks/Tutorial_PointingSys.ipynb
+++ b/notebooks/Tutorial_PointingSys.ipynb
@@ -174,7 +174,7 @@
     "pointings_ = []\n",
     "for cur_obs in sim.observations:\n",
     "    for det_idx in range(cur_obs.n_detectors):\n",
-    "        pnt, _ = cur_obs.get_pointings(det_idx, pointings_dtype=np.float32)\n",
+    "        pnt, _ = cur_obs.get_pointings(det_idx, pointings_dtype=np.float64)\n",
     "        pointings_.append(pnt)\n",
     "pointings_ = np.array(pointings_)\n",
     "\n",

--- a/notebooks/litebird_sim_example.ipynb
+++ b/notebooks/litebird_sim_example.ipynb
@@ -295,7 +295,7 @@
     "pointings = []\n",
     "for cur_obs in sim.observations:\n",
     "    for det_idx in range(cur_obs.n_detectors):\n",
-    "        pointing, _ = cur_obs.get_pointings(det_idx, pointings_dtype=np.float32)\n",
+    "        pointing, _ = cur_obs.get_pointings(det_idx, pointings_dtype=np.float64)\n",
     "        pointings.append(pointing)\n",
     "pointings = np.array(pointings)"
    ]

--- a/test/test_beam_convolution.py
+++ b/test/test_beam_convolution.py
@@ -209,7 +209,7 @@ def test_beam_convolution():
         beam_alms=blms,
         input_sky_alms_in_galactic=False,
         convolution_params=Convparams,
-        pointings_dtype=np.float32,
+        pointings_dtype=np.float64,
     )
 
     np.testing.assert_allclose(
@@ -218,3 +218,4 @@ def test_beam_convolution():
         rtol=tolerance,
         atol=0.1,
     )
+

--- a/test/test_beam_convolution.py
+++ b/test/test_beam_convolution.py
@@ -209,6 +209,7 @@ def test_beam_convolution():
         beam_alms=blms,
         input_sky_alms_in_galactic=False,
         convolution_params=Convparams,
+        pointings_dtype=np.float64,
     )
 
     np.testing.assert_allclose(

--- a/test/test_beam_convolution.py
+++ b/test/test_beam_convolution.py
@@ -209,7 +209,7 @@ def test_beam_convolution():
         beam_alms=blms,
         input_sky_alms_in_galactic=False,
         convolution_params=Convparams,
-        pointings_dtype=np.float64,
+        pointings_dtype=np.float32,
     )
 
     np.testing.assert_allclose(

--- a/test/test_beam_convolution.py
+++ b/test/test_beam_convolution.py
@@ -218,4 +218,3 @@ def test_beam_convolution():
         rtol=tolerance,
         atol=0.1,
     )
-

--- a/test/test_pointing_sys.py
+++ b/test/test_pointing_sys.py
@@ -114,7 +114,7 @@ def test_PointingSys_add_single_offset_to_FP(
     for cur_obs in sim.observations:
         for det_idx in range(cur_obs.n_detectors):
             pointings, hwp_angle = cur_obs.get_pointings(
-                det_idx, pointings_dtype=np.float32
+                det_idx, pointings_dtype=np.float64
             )
             pointings_list.append(pointings.tolist())
 
@@ -152,7 +152,7 @@ def test_PointingSys_add_multiple_offsets_to_FP(
     for cur_obs in sim.observations:
         for det_idx in range(cur_obs.n_detectors):
             pointings, hwp_angle = cur_obs.get_pointings(
-                det_idx, pointings_dtype=np.float32
+                det_idx, pointings_dtype=np.float64
             )
             pointings_list.append(pointings.tolist())
 
@@ -198,7 +198,7 @@ def test_PointingSys_add_uncommon_disturb_to_FP(
     for cur_obs in sim.observations:
         for det_idx in range(cur_obs.n_detectors):
             pointings, hwp_angle = cur_obs.get_pointings(
-                det_idx, pointings_dtype=np.float32
+                det_idx, pointings_dtype=np.float64
             )
             pointings_list.append(pointings.tolist())
 
@@ -241,7 +241,7 @@ def test_PointingSys_add_common_disturb_to_FP(
     for cur_obs in sim.observations:
         for det_idx in range(cur_obs.n_detectors):
             pointings, hwp_angle = cur_obs.get_pointings(
-                det_idx, pointings_dtype=np.float32
+                det_idx, pointings_dtype=np.float64
             )
             pointings_list.append(pointings.tolist())
 
@@ -279,7 +279,7 @@ def test_PointingSys_add_single_offset_to_spacecraft(
     for cur_obs in sim.observations:
         for det_idx in range(cur_obs.n_detectors):
             pointings, hwp_angle = cur_obs.get_pointings(
-                det_idx, pointings_dtype=np.float32
+                det_idx, pointings_dtype=np.float64
             )
             pointings_list.append(pointings.tolist())
 
@@ -321,7 +321,7 @@ def test_PointingSys_add_common_disturb_to_spacecraft(
     for cur_obs in sim.observations:
         for det_idx in range(cur_obs.n_detectors):
             pointings, hwp_angle = cur_obs.get_pointings(
-                det_idx, pointings_dtype=np.float32
+                det_idx, pointings_dtype=np.float64
             )
             pointings_list.append(pointings.tolist())
 
@@ -367,7 +367,7 @@ def test_PointingSys_add_hwp_rot_disturb(
     for cur_obs in sim.observations:
         for det_idx in range(cur_obs.n_detectors):
             pointings, hwp_angle = cur_obs.get_pointings(
-                det_idx, pointings_dtype=np.float32
+                det_idx, pointings_dtype=np.float64
             )
             pointings_list.append(pointings.tolist())
 


### PR DESCRIPTION
Fixes #374.

It should be working correctly. Now we are able to define specifically pointings_dtype  when we call the following methods:

**in scan_map.py ->** scan_map_in_observations(), scan_map()
**in dipole.py ->** add_dipole_to_observations() and add_dipole()
**in mapmaking/destriper.py ->** make_destriped_map()
**in mapmaking/binner.py ->** make_binned_map()

I tried the scan_map_in_observations in the simulation in which I had noticed this issue and this change seems to be working. I actually never used the other methods so, for us to be sure, @anand-avinash if you can please try for a simulation that uses the mapmaking ones, and @paganol for the dipole ones, and confirm that there are no problems, it would be perfect. Thank you in advance!
