### PR TITLE
Fix angles hwp sys, add pointings to DetectorInfo, fix hwp_sys notebook

### DIFF
--- a/litebird_sim/detectors.py
+++ b/litebird_sim/detectors.py
@@ -150,8 +150,9 @@ class DetectorInfo:
              for the mapmaking. It allows to have a non-ideal HWP in the solver.
              The default is None (i.e. no HWP)
 
-        - pointing_theta_phi_psi_deg (Union[None, np.ndarray]): The angles θ, φ, and ψ
-             (colatitude, longitude, and orientation) of the pointing direction, expressed in degrees
+        - pointing_theta_phi_psi_deg (Union[None, np.ndarray]): The angles θ, φ,
+             and ψ (colatitude, longitude, and orientation) of the pointing direction,
+             expressed in degrees.
     """
 
     name: str = ""

--- a/litebird_sim/detectors.py
+++ b/litebird_sim/detectors.py
@@ -149,6 +149,9 @@ class DetectorInfo:
         - mueller_hwp_solver (Union[None, np.ndarray]): mueller matrix of the HWP
              for the mapmaking. It allows to have a non-ideal HWP in the solver.
              The default is None (i.e. no HWP)
+
+        - pointing_theta_phi_psi_deg (Union[None, np.ndarray]): The angles θ, φ, and ψ
+             (colatitude, longitude, and orientation) of the pointing direction, expressed in degrees
     """
 
     name: str = ""
@@ -177,6 +180,7 @@ class DetectorInfo:
     pol_efficiency: float = 1.0
     mueller_hwp: Union[None, np.ndarray] = None
     mueller_hwp_solver: Union[None, np.ndarray] = None
+    pointing_theta_phi_psi_deg: Union[None, np.ndarray] = None
 
     def __post_init__(self):
         if self.quat is None:

--- a/litebird_sim/hwp_sys/examples/example_hwp_sys.ipynb
+++ b/litebird_sim/hwp_sys/examples/example_hwp_sys.ipynb
@@ -182,7 +182,7 @@
     "            \"quat\": quats[d],\n",
     "        }\n",
     "    )\n",
-    "    det.phi = 0\n",
+    "    det.theta_phi_psi_deg = [0,0,0]\n",
     "    det.pol_angle_rad = compute_orientation_from_detquat(quats[d]) % (2 * np.pi)\n",
     "    det.mueller_hwp = {\n",
     "        \"0f\": np.array([[1, 0, 0], [0, 0, 0], [0, 0, 0]], dtype=np.float32),\n",

--- a/litebird_sim/hwp_sys/examples/example_hwp_sys.ipynb
+++ b/litebird_sim/hwp_sys/examples/example_hwp_sys.ipynb
@@ -339,7 +339,6 @@
     "    integrate_in_band=False,\n",
     "    integrate_in_band_solver=False,\n",
     "    build_map_on_the_fly=True,\n",
-    "    correct_in_solver=True,\n",
     "    comm=comm,\n",
     ")"
    ]

--- a/litebird_sim/hwp_sys/hwp_sys.py
+++ b/litebird_sim/hwp_sys/hwp_sys.py
@@ -279,8 +279,8 @@ def compute_signal_for_one_detector(
     """
 
     for i in prange(len(tod_det)):
-        FourRho = 4 * theta[i]
-        TwoRho = 2 * theta[i]
+        FourRho = 4 * (theta[i] - phi)
+        TwoRho = 2 * (theta[i] - phi)
         tod_det[i] += compute_signal_for_one_sample(
             T=maps[0, pixel_ind[i]],
             Q=maps[1, pixel_ind[i]],
@@ -374,8 +374,8 @@ def compute_ata_atd_for_one_detector(
     """
 
     for i in prange(len(tod)):
-        FourRho = 4 * theta[i]
-        TwoRho = 2 * theta[i]
+        FourRho = 4 * (theta[i] - phi)
+        TwoRho = 2 * (theta[i] - phi)
         # psi_i = 2*np.arctan2(np.sqrt(quats_rot[i][0]**2 + quats_rot[i][1]**2 + quats_rot[i][2]**2),quats_rot[i][3])
         Tterm, Qterm, Uterm = compute_TQUsolver_for_one_sample(
             mIIs=m0f_solver[0, 0]

--- a/litebird_sim/hwp_sys/hwp_sys.py
+++ b/litebird_sim/hwp_sys/hwp_sys.py
@@ -279,8 +279,8 @@ def compute_signal_for_one_detector(
     """
 
     for i in prange(len(tod_det)):
-        FourRhoPsiPhi = 4 * (theta[i] - psi[i] - phi)
-        TwoRhoPsiPhi = 2 * (theta[i] - psi[i] - phi)
+        FourRhoPsiPhi = 4 * theta[i]
+        TwoRhoPsiPhi = 2 * theta[i]
         tod_det[i] += compute_signal_for_one_sample(
             T=maps[0, pixel_ind[i]],
             Q=maps[1, pixel_ind[i]],
@@ -374,8 +374,8 @@ def compute_ata_atd_for_one_detector(
     """
 
     for i in prange(len(tod)):
-        FourRhoPsiPhi = 4 * (theta[i] - psi[i] - phi)
-        TwoRhoPsiPhi = 2 * (theta[i] - psi[i] - phi)
+        FourRhoPsiPhi = 4 * theta[i]
+        TwoRhoPsiPhi = 2 * theta[i]
         # psi_i = 2*np.arctan2(np.sqrt(quats_rot[i][0]**2 + quats_rot[i][1]**2 + quats_rot[i][2]**2),quats_rot[i][3])
         Tterm, Qterm, Uterm = compute_TQUsolver_for_one_sample(
             mIIs=m0f_solver[0, 0]
@@ -826,7 +826,7 @@ class HwpSys:
                 # xi: polarization angle, i.e. detector dependent
                 # psi: instrument angle, i.e. boresight direction from focal plane POV
                 xi = cur_det.pol_angle_rad
-                psi = (cur_point[:, 2] - xi) % (2 * np.pi)
+                psi = cur_point[:, 2]
 
                 phi = np.deg2rad(cur_det.phi)
 
@@ -840,8 +840,8 @@ class HwpSys:
                     m2f=cur_det.mueller_hwp["2f"],
                     m4f=cur_det.mueller_hwp["4f"],
                     theta=np.array(
-                        cur_hwp_angle / 2, dtype=np.float64
-                    ),  # hwp angle returns 2 ^it
+                        cur_hwp_angle, dtype=np.float64
+                    ), 
                     psi=np.array(psi, dtype=np.float64),
                     maps=np.array(self.maps, dtype=np.float64),
                     cos2Xi2Phi=cos2Xi2Phi,
@@ -859,8 +859,8 @@ class HwpSys:
                     m4f_solver=cur_det.mueller_hwp_solver["4f"],
                     pixel_ind=pix,
                     theta=np.array(
-                        cur_hwp_angle / 2, dtype=np.float64
-                    ),  # hwp angle returns 2ωt
+                        cur_hwp_angle, dtype=np.float64
+                    ),
                     psi=np.array(psi, dtype=np.float64),
                     phi=phi,
                     cos2Xi2Phi=cos2Xi2Phi,

--- a/litebird_sim/hwp_sys/hwp_sys.py
+++ b/litebird_sim/hwp_sys/hwp_sys.py
@@ -828,7 +828,7 @@ class HwpSys:
                 xi = cur_det.pol_angle_rad
                 psi = cur_point[:, 2]
 
-                phi = np.deg2rad(cur_det.phi)
+                phi = np.deg2rad(cur_det.pointing_theta_phi_psi_deg[1])
 
                 cos2Xi2Phi = np.cos(2 * xi - 2 * phi)
                 sin2Xi2Phi = np.sin(2 * xi - 2 * phi)

--- a/litebird_sim/hwp_sys/hwp_sys.py
+++ b/litebird_sim/hwp_sys/hwp_sys.py
@@ -279,39 +279,39 @@ def compute_signal_for_one_detector(
     """
 
     for i in prange(len(tod_det)):
-        FourRhoPsiPhi = 4 * theta[i]
-        TwoRhoPsiPhi = 2 * theta[i]
+        FourRho = 4 * theta[i]
+        TwoRho = 2 * theta[i]
         tod_det[i] += compute_signal_for_one_sample(
             T=maps[0, pixel_ind[i]],
             Q=maps[1, pixel_ind[i]],
             U=maps[2, pixel_ind[i]],
             mII=m0f[0, 0]
-            + m2f[0, 0] * np.cos(TwoRhoPsiPhi - 2.32)
-            + m4f[0, 0] * np.cos(FourRhoPsiPhi - 0.84),
+            + m2f[0, 0] * np.cos(TwoRho - 2.32)
+            + m4f[0, 0] * np.cos(FourRho - 0.84),
             mQI=m0f[1, 0]
-            + m2f[1, 0] * np.cos(TwoRhoPsiPhi + 2.86)
-            + m4f[1, 0] * np.cos(FourRhoPsiPhi + 0.14),
+            + m2f[1, 0] * np.cos(TwoRho + 2.86)
+            + m4f[1, 0] * np.cos(FourRho + 0.14),
             mUI=m0f[2, 0]
-            + m2f[2, 0] * np.cos(TwoRhoPsiPhi + 1.29)
-            + m4f[2, 0] * np.cos(FourRhoPsiPhi - 1.43),
+            + m2f[2, 0] * np.cos(TwoRho + 1.29)
+            + m4f[2, 0] * np.cos(FourRho - 1.43),
             mIQ=m0f[0, 1]
-            + m2f[0, 1] * np.cos(TwoRhoPsiPhi - 0.49)
-            + m4f[0, 1] * np.cos(FourRhoPsiPhi - 0.04),
+            + m2f[0, 1] * np.cos(TwoRho - 0.49)
+            + m4f[0, 1] * np.cos(FourRho - 0.04),
             mIU=m0f[0, 2]
-            + m2f[0, 2] * np.cos(TwoRhoPsiPhi - 2.06)
-            + m4f[0, 2] * np.cos(FourRhoPsiPhi - 1.61),
+            + m2f[0, 2] * np.cos(TwoRho - 2.06)
+            + m4f[0, 2] * np.cos(FourRho - 1.61),
             mQQ=m0f[1, 1]
-            + m2f[1, 1] * np.cos(TwoRhoPsiPhi - 0.25)
-            + m4f[1, 1] * np.cos(FourRhoPsiPhi - 0.00061),
+            + m2f[1, 1] * np.cos(TwoRho - 0.25)
+            + m4f[1, 1] * np.cos(FourRho - 0.00061),
             mUU=m0f[2, 2]
-            + m2f[2, 2] * np.cos(TwoRhoPsiPhi + 2.54)
-            + m4f[2, 2] * np.cos(FourRhoPsiPhi + np.pi - 0.00065),
+            + m2f[2, 2] * np.cos(TwoRho + 2.54)
+            + m4f[2, 2] * np.cos(FourRho + np.pi - 0.00065),
             mUQ=m0f[2, 1]
-            + m2f[2, 1] * np.cos(TwoRhoPsiPhi - 2.01)
-            + m4f[2, 1] * np.cos(FourRhoPsiPhi - 0.00070 - np.pi / 2),
+            + m2f[2, 1] * np.cos(TwoRho - 2.01)
+            + m4f[2, 1] * np.cos(FourRho - 0.00070 - np.pi / 2),
             mQU=m0f[1, 2]
-            + m2f[1, 2] * np.cos(TwoRhoPsiPhi - 2.00)
-            + m4f[1, 2] * np.cos(FourRhoPsiPhi - 0.00056 - np.pi / 2),
+            + m2f[1, 2] * np.cos(TwoRho - 2.00)
+            + m4f[1, 2] * np.cos(FourRho - 0.00056 - np.pi / 2),
             psi=psi[i],
             phi=phi,
             cos2Xi2Phi=cos2Xi2Phi,
@@ -374,37 +374,37 @@ def compute_ata_atd_for_one_detector(
     """
 
     for i in prange(len(tod)):
-        FourRhoPsiPhi = 4 * theta[i]
-        TwoRhoPsiPhi = 2 * theta[i]
+        FourRho = 4 * theta[i]
+        TwoRho = 2 * theta[i]
         # psi_i = 2*np.arctan2(np.sqrt(quats_rot[i][0]**2 + quats_rot[i][1]**2 + quats_rot[i][2]**2),quats_rot[i][3])
         Tterm, Qterm, Uterm = compute_TQUsolver_for_one_sample(
             mIIs=m0f_solver[0, 0]
-            + m2f_solver[0, 0] * np.cos(TwoRhoPsiPhi - 2.32)
-            + m4f_solver[0, 0] * np.cos(FourRhoPsiPhi - 0.84),
+            + m2f_solver[0, 0] * np.cos(TwoRho - 2.32)
+            + m4f_solver[0, 0] * np.cos(FourRho - 0.84),
             mQIs=m0f_solver[1, 0]
-            + m2f_solver[1, 0] * np.cos(TwoRhoPsiPhi + 2.86)
-            + m4f_solver[1, 0] * np.cos(FourRhoPsiPhi + 0.14),
+            + m2f_solver[1, 0] * np.cos(TwoRho + 2.86)
+            + m4f_solver[1, 0] * np.cos(FourRho + 0.14),
             mUIs=m0f_solver[2, 0]
-            + m2f_solver[2, 0] * np.cos(TwoRhoPsiPhi + 1.29)
-            + m4f_solver[2, 0] * np.cos(FourRhoPsiPhi - 1.43),
+            + m2f_solver[2, 0] * np.cos(TwoRho + 1.29)
+            + m4f_solver[2, 0] * np.cos(FourRho - 1.43),
             mIQs=m0f_solver[0, 1]
-            + m2f_solver[0, 1] * np.cos(TwoRhoPsiPhi - 0.49)
-            + m4f_solver[0, 1] * np.cos(FourRhoPsiPhi - 0.04),
+            + m2f_solver[0, 1] * np.cos(TwoRho - 0.49)
+            + m4f_solver[0, 1] * np.cos(FourRho - 0.04),
             mIUs=m0f_solver[0, 2]
-            + m2f_solver[0, 2] * np.cos(TwoRhoPsiPhi - 2.06)
-            + m4f_solver[0, 2] * np.cos(FourRhoPsiPhi - 1.61),
+            + m2f_solver[0, 2] * np.cos(TwoRho - 2.06)
+            + m4f_solver[0, 2] * np.cos(FourRho - 1.61),
             mQQs=m0f_solver[1, 1]
-            + m2f_solver[1, 1] * np.cos(TwoRhoPsiPhi - 0.25)
-            + m4f_solver[1, 1] * np.cos(FourRhoPsiPhi - 0.00061),
+            + m2f_solver[1, 1] * np.cos(TwoRho - 0.25)
+            + m4f_solver[1, 1] * np.cos(FourRho - 0.00061),
             mUUs=m0f_solver[2, 2]
-            + m2f_solver[2, 2] * np.cos(TwoRhoPsiPhi + 2.54)
-            + m4f_solver[2, 2] * np.cos(FourRhoPsiPhi + np.pi - 0.00065),
+            + m2f_solver[2, 2] * np.cos(TwoRho + 2.54)
+            + m4f_solver[2, 2] * np.cos(FourRho + np.pi - 0.00065),
             mUQs=m0f_solver[2, 1]
-            + m2f_solver[2, 1] * np.cos(TwoRhoPsiPhi - 2.01)
-            + m4f_solver[2, 1] * np.cos(FourRhoPsiPhi - 0.00070 - np.pi / 2),
+            + m2f_solver[2, 1] * np.cos(TwoRho - 2.01)
+            + m4f_solver[2, 1] * np.cos(FourRho - 0.00070 - np.pi / 2),
             mQUs=m0f_solver[1, 2]
-            + m2f_solver[1, 2] * np.cos(TwoRhoPsiPhi - 2.00)
-            + m4f_solver[1, 2] * np.cos(FourRhoPsiPhi - 0.00056 - np.pi / 2),
+            + m2f_solver[1, 2] * np.cos(TwoRho - 2.00)
+            + m4f_solver[1, 2] * np.cos(FourRho - 0.00056 - np.pi / 2),
             psi=psi[i],
             phi=phi,
             cos2Xi2Phi=cos2Xi2Phi,
@@ -839,9 +839,7 @@ class HwpSys:
                     m0f=cur_det.mueller_hwp["0f"],
                     m2f=cur_det.mueller_hwp["2f"],
                     m4f=cur_det.mueller_hwp["4f"],
-                    theta=np.array(
-                        cur_hwp_angle, dtype=np.float64
-                    ), 
+                    theta=np.array(cur_hwp_angle, dtype=np.float64),
                     psi=np.array(psi, dtype=np.float64),
                     maps=np.array(self.maps, dtype=np.float64),
                     cos2Xi2Phi=cos2Xi2Phi,
@@ -858,9 +856,7 @@ class HwpSys:
                     m2f_solver=cur_det.mueller_hwp_solver["2f"],
                     m4f_solver=cur_det.mueller_hwp_solver["4f"],
                     pixel_ind=pix,
-                    theta=np.array(
-                        cur_hwp_angle, dtype=np.float64
-                    ),
+                    theta=np.array(cur_hwp_angle, dtype=np.float64),
                     psi=np.array(psi, dtype=np.float64),
                     phi=phi,
                     cos2Xi2Phi=cos2Xi2Phi,

--- a/test/test_hwp_sys.py
+++ b/test/test_hwp_sys.py
@@ -51,7 +51,7 @@ def test_hwp_sys():
                 "quat": quats[d],
             }
         )
-        det.phi = 133.2
+        det.pointing_theta_phi_psi_deg = [0, 132, 0]
         dets.append(det)
 
     scan_strat = lbs.SpinningScanningStrategy(
@@ -156,7 +156,7 @@ def test_hwp_sys():
             }
         )
 
-        det.phi = 45
+        det.pointing_theta_phi_psi_deg = [0, 45, 0]
         dets2.append(det)
 
     (new_obs,) = sim.create_observations(detectors=dets2)

--- a/test/test_hwp_sys.py
+++ b/test/test_hwp_sys.py
@@ -202,7 +202,6 @@ def test_hwp_sys():
 
 
 def test_hwp_sys_angles():
-    
     # testing if the angles are well defined (the tod computed with hwp_sys and the one
     # computed with scan_map must be the same)
 

--- a/test/test_hwp_sys.py
+++ b/test/test_hwp_sys.py
@@ -2,6 +2,7 @@ import litebird_sim as lbs
 import numpy as np
 from litebird_sim.hwp_sys.hwp_sys import compute_orientation_from_detquat
 from litebird_sim import mpi
+from litebird_sim.scan_map import scan_map_in_observations
 
 
 def test_hwp_sys():
@@ -198,3 +199,126 @@ def test_hwp_sys():
 
     output_maps = hwp_sys.make_map([obs])
     np.testing.assert_almost_equal(input_maps, output_maps, decimal=9, verbose=True)
+
+
+def test_hwp_sys_angles():
+    
+    # testing if the angles are well defined (the tod computed with hwp_sys and the one
+    # computed with scan_map must be the same)
+
+    start_time = 0
+    time_span_s = 1000
+    nside = 64
+    sampling = 1
+    hwp_radpsec = lbs.IdealHWP(
+        46 * 2 * np.pi / 60,
+    ).ang_speed_radpsec
+
+    sim = lbs.Simulation(start_time=start_time, duration_s=time_span_s, random_seed=0)
+
+    sim.set_hwp(lbs.IdealHWP(hwp_radpsec))
+
+    comm = sim.mpi_comm
+    rank = comm.rank
+
+    channelinfo = lbs.FreqChannelInfo(
+        bandcenter_ghz=140.0,
+        channel="L4-140",
+        bandwidth_ghz=42.0,
+        net_detector_ukrts=38.44,
+        net_channel_ukrts=3.581435543962163,
+        pol_sensitivity_channel_ukarcmin=7.24525963532118,
+    )
+
+    det = lbs.DetectorInfo.from_dict(
+        {
+            "channel": channelinfo,
+            "bandcenter_ghz": 140.0,
+            "sampling_rate_hz": sampling,
+            "quat": [0.03967584136504414, 0.03725809501267564, 0.0, 0.9985177324254199],
+        }
+    )
+
+    scan_strat = lbs.SpinningScanningStrategy(
+        spin_sun_angle_rad=np.deg2rad(45.0),
+        precession_rate_hz=1.0 / (60.0 * 192.348),
+        spin_rate_hz=0.05 / 60.0,
+    )
+
+    sim.set_scanning_strategy(append_to_report=False, scanning_strategy=scan_strat)
+
+    instr = lbs.InstrumentInfo(
+        name="LFT",
+        boresight_rotangle_rad=0.0,
+        spin_boresight_angle_rad=0.8726646259971648,
+        spin_rotangle_rad=0.0,
+        hwp_rpm=46.0,
+        number_of_channels=1,
+    )
+
+    sim.set_instrument(instr)
+
+    (obs_scan,) = sim.create_observations(
+        detectors=[det],
+        n_blocks_det=comm.size,
+        split_list_over_processes=False,
+    )
+
+    for idet in range(obs_scan.n_detectors):
+        sim.detectors[idet].pol_angle_rad = compute_orientation_from_detquat(
+            obs_scan.quat[idet].quats[0]
+        ) % (2 * np.pi)
+        sim.detectors[idet].pointing_theta_phi_psi_deg = [0, 0, 0]
+
+    sim.prepare_pointings(append_to_report=False)
+
+    Mbsparams = lbs.MbsParameters(
+        make_cmb=True,
+        seed_cmb=1234,
+        make_noise=False,
+        make_dipole=True,
+        make_fg=True,
+        fg_models=["pysm_synch_0", "pysm_dust_0", "pysm_freefree_1"],
+        gaussian_smooth=True,
+        bandpass_int=False,
+        maps_in_ecliptic=True,
+        nside=nside,
+        units="K_CMB",
+    )
+
+    if rank == 0:
+        mbs = lbs.Mbs(simulation=sim, parameters=Mbsparams, channel_list=[channelinfo])
+
+        input_maps = mbs.run_all()[0]["L4-140"]
+    else:
+        input_maps = None
+
+    if mpi.MPI_ENABLED:
+        input_maps = comm.bcast(input_maps, root=0)
+
+    hwp_sys = lbs.HwpSys(sim)
+
+    hwp_sys.set_parameters(
+        nside=nside,
+        maps=input_maps,
+        Channel=channelinfo,
+        Mbsparams=Mbsparams,
+        integrate_in_band=False,
+        integrate_in_band_solver=False,
+        build_map_on_the_fly=True,
+        comm=comm,
+    )
+
+    obs_hwpsys = obs_scan
+
+    scan_map_in_observations(
+        observations=obs_scan,
+        maps=input_maps,
+    )
+
+    hwp_sys.fill_tod(
+        observations=[obs_hwpsys],
+        input_map_in_galactic=False,
+    )
+
+    np.testing.assert_equal(obs_scan.tod, obs_hwpsys.tod, verbose=True)

--- a/test/test_mpi.py
+++ b/test/test_mpi.py
@@ -277,7 +277,7 @@ def test_observation_tod_set_blocks():
             )
             assert np.all(obs.row_int.astype(str) == obs.row_str)
         else:
-            assert obs.row_int is None
+            assert obs.row_int == [None]
             assert obs.row_str is None
 
     # Two time blocks

--- a/test/test_mpi.py
+++ b/test/test_mpi.py
@@ -278,7 +278,7 @@ def test_observation_tod_set_blocks():
             assert np.all(obs.row_int.astype(str) == obs.row_str)
         else:
             assert obs.row_int == [None]
-            assert obs.row_str is None
+            assert obs.row_str == [None]
 
     # Two time blocks
     ref_tod = np.arange(27, dtype=np.float32).reshape(3, 9)


### PR DESCRIPTION
This pull request:

- **Changes the definition of the hwp angle and the psi angle in hwp_sys.py,** 
because they were defined according to the previous LBS version (hwp_angle was half of its value, and psi was mixed with the polarization angle). So now psi is simply the 3rd element of the pointings array (can you confirm if this is correct, @paganol ?). There was also an error in the hwp_sys model implementation because I considered the hwp_angle as if it was w.r.t the sky coordinates, while it is in fact defined w.r.t the focal plane.

- **Adds pointing_theta_phi_psi_deg attribute to the DetectorInfo class.**
It is now obtained automatically from the imo and can be used in cases where we need the detector's position in the focal plane in terms of theta, phi and psi. It is useful for example for hwp_sys.

- **Fixes the test_mpi.py bug that was resulting in test failures.**
This is the problem that I talked about in the meeting this morning. @anand-avinash kindly sent me a solution for this, and it seems to be working now.

- **Removes correct_in_solver reference in the hwp_sys example notebook,**
as in the current version of hwp_sys.py there is no longer a correct_in_solver attribute.


If you see any problem, please let me know. Thank you.

