### PR TITLE
Update deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 -   **Breaking change**: The HWP and ψ angles in the HWP Systematics module have been redefined to be consistent [#377](https://github.com/litebird/litebird_sim/pull/377)
 
+-   Deprecate `apply_hwp_to_obs()` and `HWP.add_hwp_angle()`, remove deprecated functions `Simulation.generate_spin2ecl_quaternions()` and `write_observations()`
+
 -   Fix docstrings and type hints for `mueller_hwp` [#381](https://github.com/litebird/litebird_sim/pull/381)
 
 -   Fix the formatting of a few docstrings [#391](https://github.com/litebird/litebird_sim/pull/391)

--- a/litebird_sim/__init__.py
+++ b/litebird_sim/__init__.py
@@ -79,7 +79,6 @@ from .imo import (
 )
 from .io import (
     write_list_of_observations,
-    write_observations,
     read_list_of_observations,
 )
 from .madam import save_simulation_for_madam

--- a/litebird_sim/hwp.py
+++ b/litebird_sim/hwp.py
@@ -4,6 +4,7 @@ from typing import Optional
 import h5py
 import numpy as np
 import numpy.typing as npt
+from deprecated import deprecated
 from numba import njit
 
 mueller_ideal_hwp = np.diag([1.0, 1.0, -1.0, -1.0])
@@ -40,6 +41,11 @@ class HWP:
             "You should not use the HWP class in your code, use IdealHWP instead"
         )
 
+    @deprecated(
+        version="0.15.0",
+        reason="This function adds the HWP angle to the orientation, but this is logically wrong "
+        "now that LBS keeps track of ψ, the polarization angle, and the HWP angle in separate places.",
+    )
     def add_hwp_angle(
         self, pointing_buffer, start_time_s: float, delta_time_s: float
     ) -> None:

--- a/litebird_sim/io.py
+++ b/litebird_sim/io.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, List, Union, Optional
 import astropy.time
 import h5py
 import numpy as np
-from deprecation import deprecated
 
 from .compress import rle_compress, rle_decompress
 from .detectors import DetectorInfo
@@ -20,7 +19,6 @@ from .mpi import MPI_ENABLED, MPI_COMM_WORLD
 from .observations import Observation, TodDescription
 from .pointings import PointingProvider
 from .scanning import RotQuaternion
-from .version import __version__ as litebird_sim_version
 
 __NUMPY_INT_TYPES = [
     np.int8,
@@ -522,27 +520,6 @@ def write_list_of_observations(
         file_list.append(file_name)
 
     return file_list
-
-
-@deprecated(
-    deprecated_in="0.11",
-    current_version=litebird_sim_version,
-    details="Use Simulation.write_observations",
-)
-def write_observations(
-    sim,
-    subdir_name: Union[None, str] = "tod",
-    include_in_report: bool = True,
-    *args,
-    **kwargs,
-) -> List[Path]:
-    # Here we call the method moved inside Simulation
-    return sim.write_observations(
-        subdir_name,
-        include_in_report,
-        *args,
-        **kwargs,
-    )
 
 
 def __find_flags(inpf, expected_num_of_dets: int, expected_num_of_samples: int):

--- a/litebird_sim/pointings.py
+++ b/litebird_sim/pointings.py
@@ -5,18 +5,22 @@ from typing import Optional, Union, List, Tuple, Callable
 import astropy.time
 import numpy as np
 import numpy.typing as npt
+from deprecated import deprecated
 
+from .coordinates import CoordinateSystem, rotate_coordinates_e2g
 from .hwp import HWP
+from .observations import Observation
 from .scanning import (
     all_compute_pointing_and_orientation,
     RotQuaternion,
 )
 
-from .coordinates import CoordinateSystem, rotate_coordinates_e2g
 
-from .observations import Observation
-
-
+@deprecated(
+    version="0.15.0",
+    reason="This function adds the HWP angle to the orientation, but this is logically wrong "
+    "now that LBS keeps track of ψ, the polarization angle, and the HWP angle in separate places.",
+)
 def apply_hwp_to_obs(observations, hwp: HWP, pointing_matrix):
     """Modify a pointing matrix to consider the effect of a HWP
 

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -22,11 +22,15 @@ import matplotlib.pylab as plt
 import numba
 import numpy as np
 import tomlkit
-from deprecation import deprecated
 from markdown_katex import KatexExtension
 
 from litebird_sim import constants
 from . import HWP
+from .beam_convolution import (
+    add_convolved_sky_to_observations,
+    BeamConvolutionParameters,
+)
+from .beam_synthesis import generate_gauss_beam_alms
 from .coordinates import CoordinateSystem
 from .detectors import DetectorInfo, InstrumentInfo
 from .dipole import DipoleType, add_dipole_to_observations
@@ -46,6 +50,7 @@ from .mapmaking import (
     DestriperResult,
     destriper_log_callback,
 )
+from .mbs import Mbs, MbsParameters
 from .mpi import MPI_ENABLED, MPI_COMM_WORLD, MPI_COMM_GRID
 from .noise import add_noise_to_observations
 from .non_linearity import apply_quadratic_nonlin_to_observations
@@ -53,15 +58,9 @@ from .observations import Observation, TodDescription
 from .pointings_in_obs import prepare_pointings, precompute_pointings
 from .profiler import TimeProfiler, profile_list_to_speedscope
 from .scan_map import scan_map_in_observations
-from .beam_convolution import (
-    add_convolved_sky_to_observations,
-    BeamConvolutionParameters,
-)
-from .spherical_harmonics import SphericalHarmonics
-from .beam_synthesis import generate_gauss_beam_alms
 from .scanning import ScanningStrategy, SpinningScanningStrategy
 from .spacecraft import SpacecraftOrbit, spacecraft_pos_and_vel
-from .mbs import Mbs, MbsParameters
+from .spherical_harmonics import SphericalHarmonics
 from .version import (
     __version__ as litebird_sim_version,
     __author__ as litebird_sim_author,
@@ -1246,25 +1245,6 @@ class Simulation:
                 delta_time_s=delta_time_s,
                 quat_memory_size_bytes=quat_memory_size_bytes,
             )
-
-    @deprecated(
-        deprecated_in="0.9",
-        current_version=litebird_sim_version,
-        details="Use set_scanning_strategy",
-    )
-    def generate_spin2ecl_quaternions(
-        self,
-        scanning_strategy: Union[None, ScanningStrategy] = None,
-        imo_url: Union[None, str] = None,
-        delta_time_s: float = 60.0,
-        append_to_report=True,
-    ):
-        self.set_scanning_strategy(
-            scanning_strategy=scanning_strategy,
-            imo_url=imo_url,
-            delta_time_s=delta_time_s,
-            append_to_report=append_to_report,
-        )
 
     def set_instrument(self, instrument: InstrumentInfo):
         """Set the instrument to be used in the simulation.


### PR DESCRIPTION
- Remove deprecated function `write_observations`
- Remove deprecated method `Simulation.generate_spin2ecl_quaternions()`
- Deprecate `HWP.add_hwp_angle()`
- Deprecate `apply_hwp_to_obs()`
