### PR TITLE
`MPI_COMM_GRID` cleanup

### DIFF
--- a/litebird_sim/__init__.py
+++ b/litebird_sim/__init__.py
@@ -82,7 +82,7 @@ from .io import (
 )
 from .madam import save_simulation_for_madam
 from .mbs.mbs import Mbs, MbsParameters, MbsSavedMapInfo
-from .mpi import MPI_COMM_WORLD, MPI_ENABLED, MPI_CONFIGURATION, MPI_COMM_GRID
+from .mpi import MPI_COMM_WORLD, MPI_ENABLED, MPI_CONFIGURATION
 from .mueller_convolver import MuellerConvolver
 from .noise import (
     add_white_noise,
@@ -239,7 +239,6 @@ __all__ = [
     "MPI_COMM_WORLD",
     "MPI_ENABLED",
     "MPI_CONFIGURATION",
-    "MPI_COMM_GRID",
     # mueller_convolver.py
     "MuellerConvolver",
     # observations.py

--- a/litebird_sim/io.py
+++ b/litebird_sim/io.py
@@ -470,7 +470,7 @@ def write_list_of_observations(
         observations = [observations]
     except IndexError:
         # Empty list
-        # We do not want to return here, as we still need to participate to
+        # We do not want to return here, as we still need to participate in
         # the call to _compute_global_start_index below
         observations = []  # type: List[Observation]
 

--- a/litebird_sim/mapmaking/common.py
+++ b/litebird_sim/mapmaking/common.py
@@ -8,7 +8,6 @@ from ducc0.healpix import Healpix_Base
 from numba import njit
 
 from litebird_sim.coordinates import CoordinateSystem
-from litebird_sim.mpi import MPI_COMM_GRID
 from litebird_sim.observations import Observation
 from litebird_sim.pointings_in_obs import _get_pointings_array, _get_pol_angle
 
@@ -109,15 +108,14 @@ def get_map_making_weights(
     except AttributeError:
         weights = np.ones(observations.n_detectors)
 
-    if check and MPI_COMM_GRID.COMM_OBS_GRID != MPI_COMM_GRID.COMM_NULL:
-        if check:
-            # Check that there are no weird weights
-            assert np.all(np.isfinite(weights)), (
-                f"Not all the detectors' weights are finite numbers: {weights}"
-            )
-            assert np.all(weights > 0.0), (
-                f"Not all the detectors' weights are positive: {weights}"
-            )
+    if check:
+        # Check that there are no weird weights
+        assert np.all(np.isfinite(weights)), (
+            f"Not all the detectors' weights are finite numbers: {weights}"
+        )
+        assert np.all(weights > 0.0), (
+            f"Not all the detectors' weights are positive: {weights}"
+        )
 
     return weights
 

--- a/litebird_sim/mapmaking/destriper.py
+++ b/litebird_sim/mapmaking/destriper.py
@@ -14,7 +14,7 @@ from numba import njit, prange
 
 from litebird_sim.coordinates import CoordinateSystem, coord_sys_to_healpix_string
 from litebird_sim.hwp import HWP
-from litebird_sim.mpi import MPI_ENABLED, MPI_COMM_WORLD, MPI_COMM_GRID
+from litebird_sim.mpi import MPI_ENABLED, MPI_COMM_WORLD
 from litebird_sim.observations import Observation
 from litebird_sim.pointings_in_obs import (
     _get_hwp_angle,
@@ -44,7 +44,7 @@ if MPI_ENABLED:
 
 
 __DESTRIPER_RESULTS_FILE_NAME = "destriper_results.fits"
-__BASELINES_FILE_NAME = f"baselines_mpi{MPI_COMM_GRID.COMM_OBS_GRID.rank:04d}.fits"
+__BASELINES_FILE_NAME = f"baselines_mpi{MPI_COMM_WORLD.rank:04d}.fits"
 
 
 def _split_items_into_n_segments(n: int, num_of_segments: int) -> List[int]:
@@ -495,10 +495,8 @@ def _build_nobs_matrix(
         )
 
     # Now we must accumulate the result of every MPI process
-    if MPI_ENABLED and MPI_COMM_GRID.COMM_OBS_GRID != MPI_COMM_GRID.COMM_NULL:
-        MPI_COMM_GRID.COMM_OBS_GRID.Allreduce(
-            mpi4py.MPI.IN_PLACE, nobs_matrix, op=mpi4py.MPI.SUM
-        )
+    if MPI_ENABLED:
+        MPI_COMM_WORLD.Allreduce(mpi4py.MPI.IN_PLACE, nobs_matrix, op=mpi4py.MPI.SUM)
 
     # `nobs_matrix_cholesky` will *not* contain the M_i maps shown in
     # Eq. 9 of KurkiSuonio2009, but its Cholesky decomposition, i.e.,
@@ -745,12 +743,8 @@ def _compute_binned_map(
             )
 
     if MPI_ENABLED:
-        MPI_COMM_GRID.COMM_OBS_GRID.Allreduce(
-            mpi4py.MPI.IN_PLACE, output_sky_map, op=mpi4py.MPI.SUM
-        )
-        MPI_COMM_GRID.COMM_OBS_GRID.Allreduce(
-            mpi4py.MPI.IN_PLACE, output_hit_map, op=mpi4py.MPI.SUM
-        )
+        MPI_COMM_WORLD.Allreduce(mpi4py.MPI.IN_PLACE, output_sky_map, op=mpi4py.MPI.SUM)
+        MPI_COMM_WORLD.Allreduce(mpi4py.MPI.IN_PLACE, output_hit_map, op=mpi4py.MPI.SUM)
 
     # Step 2: compute the “binned map” (Eq. 21)
     _sum_map_to_binned_map(
@@ -990,7 +984,7 @@ def _mpi_dot(a: List[npt.ArrayLike], b: List[npt.ArrayLike]) -> float:
     # the dot product
     local_result = sum([np.dot(x1.flatten(), x2.flatten()) for (x1, x2) in zip(a, b)])
     if MPI_ENABLED:
-        return MPI_COMM_GRID.COMM_OBS_GRID.allreduce(local_result, op=mpi4py.MPI.SUM)
+        return MPI_COMM_WORLD.allreduce(local_result, op=mpi4py.MPI.SUM)
     else:
         return local_result
 
@@ -1007,7 +1001,7 @@ def _get_stopping_factor(residual: List[npt.ArrayLike]) -> float:
     """
     local_result = np.max(np.abs(residual))
     if MPI_ENABLED:
-        return MPI_COMM_GRID.COMM_OBS_GRID.allreduce(local_result, op=mpi4py.MPI.MAX)
+        return MPI_COMM_WORLD.allreduce(local_result, op=mpi4py.MPI.MAX)
     else:
         return local_result
 
@@ -1421,7 +1415,7 @@ def _run_destriper(
     bytes_in_temporary_buffers += mask.nbytes
 
     if MPI_ENABLED:
-        bytes_in_temporary_buffers = MPI_COMM_GRID.COMM_OBS_GRID.allreduce(
+        bytes_in_temporary_buffers = MPI_COMM_WORLD.allreduce(
             bytes_in_temporary_buffers,
             op=mpi4py.MPI.SUM,
         )
@@ -1623,103 +1617,91 @@ def make_destriped_map(
     binned_map = np.empty((3, number_of_pixels))
     hit_map = np.empty(number_of_pixels)
 
-    if MPI_COMM_GRID.COMM_OBS_GRID != MPI_COMM_GRID.COMM_NULL:
-        # perform the following operations when MPI is not being used
-        # OR when the MPI_COMM_GRID.COMM_OBS_GRID is not a NULL communicator
-        if do_destriping:
-            try:
-                # This will fail if the parameter is a scalar
-                len(params.samples_per_baseline)
+    # perform the following operations when MPI is not being used
+    if do_destriping:
+        try:
+            # This will fail if the parameter is a scalar
+            len(params.samples_per_baseline)
 
-                baseline_lengths_list = params.samples_per_baseline
-                assert len(baseline_lengths_list) == len(obs_list), (
-                    f"The list baseline_lengths_list has {len(baseline_lengths_list)} "
-                    f"elements, but there are {len(obs_list)} observations"
-                )
-            except TypeError:
-                # Ok, params.samples_per_baseline is a scalar, so we must
-                # figure out the number of samples in each baseline within
-                # each observation
-                baseline_lengths_list = [
-                    split_items_evenly(
-                        n=getattr(cur_obs, components[0]).shape[1],
-                        sub_n=int(params.samples_per_baseline),
-                    )
-                    for cur_obs in obs_list
-                ]
-
-            # Each element of this list is a 2D array with shape (N_det, N_baselines),
-            # where N_det is the number of detectors in the i-th Observation object
-            recycle_baselines = False
-            if baselines_list is None:
-                baselines_list = [
-                    np.zeros(
-                        (getattr(cur_obs, components[0]).shape[0], len(cur_baseline))
-                    )
-                    for (cur_obs, cur_baseline) in zip(obs_list, baseline_lengths_list)
-                ]
-            else:
-                recycle_baselines = True
-
-            destriped_map = np.empty((3, number_of_pixels))
-            (
-                baselines_list,
-                baseline_errors_list,
-                history_of_stopping_factors,
-                best_stopping_factor,
-                converged,
-                bytes_in_temporary_buffers,
-            ) = _run_destriper(
-                obs_list=obs_list,
-                nobs_matrix_cholesky=nobs_matrix_cholesky,
-                binned_map=binned_map,
-                destriped_map=destriped_map,
-                hit_map=hit_map,
-                baseline_lengths_list=baseline_lengths_list,
-                baselines_list_start=baselines_list,
-                recycle_baselines=recycle_baselines,
-                recycled_convergence=recycled_convergence,
-                dm_list=detector_mask_list,
-                tm_list=time_mask_list,
-                component=components[0],
-                threshold=params.threshold,
-                max_steps=params.iter_max,
-                use_preconditioner=params.use_preconditioner,
-                callback=callback,
-                callback_kwargs=callback_kwargs if callback_kwargs else {},
+            baseline_lengths_list = params.samples_per_baseline
+            assert len(baseline_lengths_list) == len(obs_list), (
+                f"The list baseline_lengths_list has {len(baseline_lengths_list)} "
+                f"elements, but there are {len(obs_list)} observations"
             )
-
-            if MPI_ENABLED:
-                bytes_in_temporary_buffers = MPI_COMM_GRID.COMM_OBS_GRID.allreduce(
-                    bytes_in_temporary_buffers,
-                    op=mpi4py.MPI.SUM,
+        except TypeError:
+            # Ok, params.samples_per_baseline is a scalar, so we must
+            # figure out the number of samples in each baseline within
+            # each observation
+            baseline_lengths_list = [
+                split_items_evenly(
+                    n=getattr(cur_obs, components[0]).shape[1],
+                    sub_n=int(params.samples_per_baseline),
                 )
+                for cur_obs in obs_list
+            ]
+
+        # Each element of this list is a 2D array with shape (N_det, N_baselines),
+        # where N_det is the number of detectors in the i-th Observation object
+        recycle_baselines = False
+        if baselines_list is None:
+            baselines_list = [
+                np.zeros((getattr(cur_obs, components[0]).shape[0], len(cur_baseline)))
+                for (cur_obs, cur_baseline) in zip(obs_list, baseline_lengths_list)
+            ]
         else:
-            # No need to run the destriping, just compute the binned map with
-            # one single baseline set to zero
-            _compute_binned_map(
-                obs_list=obs_list,
-                output_sky_map=binned_map,
-                output_hit_map=hit_map,
-                nobs_matrix_cholesky=nobs_matrix_cholesky,
-                component=components[0],
-                dm_list=detector_mask_list,
-                tm_list=time_mask_list,
-                baselines_list=None,
-                baseline_lengths_list=[
-                    np.array([getattr(cur_obs, components[0]).shape[1]], dtype=int)
-                    for cur_obs in obs_list
-                ],
+            recycle_baselines = True
+
+        destriped_map = np.empty((3, number_of_pixels))
+        (
+            baselines_list,
+            baseline_errors_list,
+            history_of_stopping_factors,
+            best_stopping_factor,
+            converged,
+            bytes_in_temporary_buffers,
+        ) = _run_destriper(
+            obs_list=obs_list,
+            nobs_matrix_cholesky=nobs_matrix_cholesky,
+            binned_map=binned_map,
+            destriped_map=destriped_map,
+            hit_map=hit_map,
+            baseline_lengths_list=baseline_lengths_list,
+            baselines_list_start=baselines_list,
+            recycle_baselines=recycle_baselines,
+            recycled_convergence=recycled_convergence,
+            dm_list=detector_mask_list,
+            tm_list=time_mask_list,
+            component=components[0],
+            threshold=params.threshold,
+            max_steps=params.iter_max,
+            use_preconditioner=params.use_preconditioner,
+            callback=callback,
+            callback_kwargs=callback_kwargs if callback_kwargs else {},
+        )
+
+        if MPI_ENABLED:
+            bytes_in_temporary_buffers = MPI_COMM_WORLD.allreduce(
+                bytes_in_temporary_buffers,
+                op=mpi4py.MPI.SUM,
             )
-            bytes_in_temporary_buffers = 0
-            destriped_map = None
-            baseline_lengths_list = None
-            baselines_list = None
-            baseline_errors_list = None
-            history_of_stopping_factors = None
-            best_stopping_factor = None
-            converged = True
     else:
+        # No need to run the destriping, just compute the binned map with
+        # one single baseline set to zero
+        _compute_binned_map(
+            obs_list=obs_list,
+            output_sky_map=binned_map,
+            output_hit_map=hit_map,
+            nobs_matrix_cholesky=nobs_matrix_cholesky,
+            component=components[0],
+            dm_list=detector_mask_list,
+            tm_list=time_mask_list,
+            baselines_list=None,
+            baseline_lengths_list=[
+                np.array([getattr(cur_obs, components[0]).shape[1]], dtype=int)
+                for cur_obs in obs_list
+            ],
+        )
+        bytes_in_temporary_buffers = 0
         destriped_map = None
         baseline_lengths_list = None
         baselines_list = None
@@ -2018,11 +2000,11 @@ def _save_baselines(results: DestriperResult, output_file: Path) -> None:
 
     primary_hdu = fits.PrimaryHDU()
     primary_hdu.header["MPIRANK"] = (
-        MPI_COMM_GRID.COMM_OBS_GRID.rank,
+        MPI_COMM_WORLD.rank,
         "The rank of the MPI process that wrote this file",
     )
     primary_hdu.header["MPISIZE"] = (
-        MPI_COMM_GRID.COMM_OBS_GRID.size,
+        MPI_COMM_WORLD.size,
         "The number of MPI processes used in the computation",
     )
 
@@ -2238,11 +2220,11 @@ def load_destriper_results(
             baselines_file_name = folder / __BASELINES_FILE_NAME
 
         with fits.open(baselines_file_name) as inpf:
-            assert MPI_COMM_GRID.COMM_OBS_GRID.rank == inpf[0].header["MPIRANK"], (
+            assert MPI_COMM_WORLD.rank == inpf[0].header["MPIRANK"], (
                 "You must call load_destriper_results using the "
                 "same MPI layout that was used for save_destriper_results "
             )
-            assert MPI_COMM_GRID.COMM_OBS_GRID.size == inpf[0].header["MPISIZE"], (
+            assert MPI_COMM_WORLD.size == inpf[0].header["MPISIZE"], (
                 "You must call load_destriper_results using the "
                 "same MPI layout that was used for save_destriper_results"
             )

--- a/litebird_sim/mpi.py
+++ b/litebird_sim/mpi.py
@@ -22,56 +22,10 @@ class _SerialMpiCommunicator:
     size = 1
 
 
-class _GridCommClass:
-    """
-    This class encapsulates the `COMM_OBS_GRID` and `COMM_NULL` communicators. It
-    offers explicitly defined setter functions so that the communicators cannot be
-    changed accidentally.
-
-    Attributes:
-
-        COMM_OBS_GRID (mpi4py.MPI.Intracomm): A subset of `MPI.COMM_WORLD` that
-            contain all the processes associated with non-zero observations.
-
-        COMM_NULL (mpi4py.MPI.Comm): A NULL communicator. When MPI is not enabled, it
-            is set as `None`. If MPI is enabled, it is set as `MPI.COMM_NULL`
-
-    """
-
-    def __init__(self, comm_obs_grid=_SerialMpiCommunicator(), comm_null=None):
-        self._MPI_COMM_OBS_GRID = comm_obs_grid
-        self._MPI_COMM_NULL = comm_null
-
-    @property
-    def COMM_OBS_GRID(self):
-        return self._MPI_COMM_OBS_GRID
-
-    @property
-    def COMM_NULL(self):
-        return self._MPI_COMM_NULL
-
-    def _set_comm_obs_grid(self, comm_obs_grid):
-        self._MPI_COMM_OBS_GRID = comm_obs_grid
-
-    def _set_null_comm(self, comm_null):
-        self._MPI_COMM_NULL = comm_null
-
-
 #: Global variable equal either to `mpi4py.MPI.COMM_WORLD` or a object
 #: that defines the member variables `rank = 0` and `size = 1`.
 MPI_COMM_WORLD = _SerialMpiCommunicator()
 
-
-#: Global object with two attributes:
-#:
-#: - ``COMM_OBS_GRID``: It is a partition of ``MPI_COMM_WORLD`` that includes all the
-#:   MPI processes with global rank less than ``n_blocks_time * n_blocks_det``. On MPI
-#:   processes with higher ranks, it points to NULL MPI communicator
-#:   ``mpi4py.MPI.COMM_NULL``.
-#:
-#: - ``COMM_NULL``: If :data:`.MPI_ENABLED` is ``True``, this object points to a NULL
-#:   MPI communicator (``mpi4py.MPI.COMM_NULL``). Otherwise it is ``None``.
-MPI_COMM_GRID = _GridCommClass()
 
 #: `True` if MPI should be used by the application. The value of this
 #: variable is set according to the following rules:
@@ -100,8 +54,6 @@ if _enable_mpi in [True, None]:
         from mpi4py import MPI
 
         MPI_COMM_WORLD = MPI.COMM_WORLD
-        MPI_COMM_GRID._set_comm_obs_grid(comm_obs_grid=MPI.COMM_WORLD)
-        MPI_COMM_GRID._set_null_comm(comm_null=MPI.COMM_NULL)
         MPI_ENABLED = True
         MPI_CONFIGURATION = mpi4py.get_config()
     except ImportError:

--- a/litebird_sim/observations.py
+++ b/litebird_sim/observations.py
@@ -415,11 +415,11 @@ class Observation:
                 "You can not have more time blocks than time samples "
                 f"({n_blocks_time} > {self.n_blocks_time})"
             )
-        elif self.comm.size < n_blocks_det * n_blocks_time:
+        elif self.comm.size != n_blocks_det * n_blocks_time:
             raise ValueError(
-                "Too many blocks: n_blocks_det x n_blocks_time = "
-                f"{n_blocks_det * n_blocks_time} but the number "
-                f"processes is {self.comm.size}"
+                "Number of blocks requested: n_blocks_det x n_blocks_time = "
+                f"{n_blocks_det * n_blocks_time} is not equal to the number "
+                f"of available MPI processes: comm.size = {self.comm.size}"
             )
 
     def _get_start_and_num(self, n_blocks_det, n_blocks_time):

--- a/litebird_sim/pointings_in_obs.py
+++ b/litebird_sim/pointings_in_obs.py
@@ -119,7 +119,7 @@ def _get_hwp_angle(
                 hwp_angle = obs.get_hwp_angle(pointings_dtype=pointing_dtype)
         else:
             if hasattr(obs, "mueller_hwp"):
-                assert all(m is None for m in obs.mueller_hwp), (
+                assert obs.no_mueller_hwp(), (
                     "Detectors have been initialized with a mueller_hwp,"
                     "but no HWP is either passed or initilized in the pointing"
                 )

--- a/litebird_sim/simulations.py
+++ b/litebird_sim/simulations.py
@@ -51,7 +51,7 @@ from .mapmaking import (
     destriper_log_callback,
 )
 from .mbs import Mbs, MbsParameters
-from .mpi import MPI_ENABLED, MPI_COMM_WORLD, MPI_COMM_GRID
+from .mpi import MPI_ENABLED, MPI_COMM_WORLD
 from .noise import add_noise_to_observations
 from .non_linearity import NonLinParams, apply_quadratic_nonlin_to_observations
 from .observations import Observation, TodDescription
@@ -1340,8 +1340,7 @@ class Simulation:
 
         num_of_obs = len(self.observations)
         if append_to_report and MPI_ENABLED:
-            if MPI_COMM_GRID.COMM_OBS_GRID != MPI_COMM_GRID.COMM_NULL:
-                num_of_obs = MPI_COMM_GRID.COMM_OBS_GRID.allreduce(num_of_obs)
+            num_of_obs = self.mpi_comm.allreduce(num_of_obs)
 
         if append_to_report and MPI_COMM_WORLD.rank == 0:
             template_file_path = get_template_file_path("report_quaternions.md")
@@ -1419,11 +1418,8 @@ class Simulation:
         memory_occupation = pointing_provider.bore2ecliptic_quats.quats.nbytes
         num_of_obs = len(self.observations)
         if append_to_report and MPI_ENABLED:
-            if MPI_COMM_GRID.COMM_OBS_GRID != MPI_COMM_GRID.COMM_NULL:
-                memory_occupation = MPI_COMM_GRID.COMM_OBS_GRID.allreduce(
-                    memory_occupation
-                )
-                num_of_obs = MPI_COMM_GRID.COMM_OBS_GRID.allreduce(num_of_obs)
+            memory_occupation = self.mpi_comm.allreduce(memory_occupation)
+            num_of_obs = self.mpi_comm.allreduce(num_of_obs)
 
         if append_to_report and MPI_COMM_WORLD.rank == 0:
             template_file_path = get_template_file_path("report_pointings.md")

--- a/test/test_detector_blocks.py
+++ b/test/test_detector_blocks.py
@@ -132,31 +132,15 @@ def test_mpi_subcommunicators(dets=dets):
         det_blocks_attributes=det_blocks_attribute,
     )
 
-    if lbs.MPI_COMM_GRID.COMM_OBS_GRID != lbs.MPI_COMM_GRID.COMM_NULL:
-        # since unused MPI processes stay at the end of global,
-        # communicator, the rank of the used processes in
-        # `MPI_COMM_GRID.COMM_OBS_GRID` must be same as their rank in
-        # global communicator
-        np.testing.assert_equal(lbs.MPI_COMM_GRID.COMM_OBS_GRID.rank, comm.rank)
-
-        for obs in sim.observations:
-            # comm_det_block.rank + comm_time_block.rank * n_block_time
-            # must be equal to the global communicator rank for the
-            # used processes. It follows from the way split colors
-            # were defined.
-            np.testing.assert_equal(
-                obs.comm_det_block.rank + obs.comm_time_block.rank * obs.n_blocks_time,
-                comm.rank,
-            )
-    else:
-        for obs in sim.observations:
-            # the global rank of the unused MPI processes must be larger than the number of used processes.
-            assert comm.rank > (obs.n_blocks_det * obs.n_blocks_time - 1)
-
-            # The block communicators on the unused MPI processes must
-            # be the NULL communicators
-            np.testing.assert_equal(obs.comm_det_block, lbs.MPI_COMM_GRID.COMM_NULL)
-            np.testing.assert_equal(obs.comm_time_block, lbs.MPI_COMM_GRID.COMM_NULL)
+    for obs in sim.observations:
+        # comm_det_block.rank + comm_time_block.rank * n_block_time
+        # must be equal to the global communicator rank for the
+        # used processes. It follows from the way split colors
+        # were defined.
+        np.testing.assert_equal(
+            obs.comm_det_block.rank + obs.comm_time_block.rank * obs.n_blocks_time,
+            comm.rank,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is meant to carry forward what we decided in #372. Specifically, we will stop fixing the issue #364, and instead, provide a script for user to help with determining the number of MPI processes needed to run the simulation. In case a user provides more MPI slots than needed, the code will produce an error and direct the user to relevant info on selecting the correct number of MPI slots. With these changes, there will be no need for `MPI_COMM_GRID` as `MPI_COMM_GRID.COMM_OBS_GRID` will always point to `MPI.COMM_WORLD`. So in this PR we will:

- [x] include selective incremental changes from #372
- [ ] remove `MPI_COMM_GRID` and update the code accordingly

The script for determining the correct number of MPI slots will be implemented in a separate PR.