### PR TITLE
Algebra for SphericalHarmonics

### DIFF
--- a/docs/source/beam_convolution.rst
+++ b/docs/source/beam_convolution.rst
@@ -158,20 +158,27 @@ If convolution parameters are omitted, defaults are inferred from sky and beam a
 Container for Spherical Harmonics
 ---------------------------------
 
-The :class:`SphericalHarmonics` class stores spherical harmonic coefficients. 
-In libraries like HealPy, alms are stored in NumPy arrays, but their ℓ_max and
-m_max values cannot be uniquely determined from array size (except when ℓ_max = m_max). 
-This class ensures proper handling, enforcing `mmax ≤ lmax` and consistently 
-using shape `(nstokes, ncoeff)`.
+The :class:`SphericalHarmonics` class stores spherical harmonic coefficients
+(a_{ℓm}) together with their associated metadata, such as `lmax`, `mmax`, and
+the number of Stokes parameters (`nstokes`).
 
-The class :class:`SphericalHarmonics` serves a container for the spherical harmonics 
-coefficients. The convention used in libraries like HealPy is to keep the a_ℓm coefficients
-of a spherical harmonic expansion in a plain NumPy array. However, this is
-ambiguous because it is not possible to uniquely determine the value of
-ℓ_max and m_max from the size of the array (unless you assume that ℓ_max == m_max)
-This class allows to store any set of alms with the only restriction that `m_max≤l_max`
-The shape of alms stored is *always* ``(nstokes, ncoeff)``, even if ``nstokes == 1``
-It also provides :func:`.resize_alm`, allowing alms to be resized via zero-padding or truncation. 
+In libraries like HealPy, the a_{ℓm} coefficients are stored in plain NumPy arrays.
+However, this representation is ambiguous: the values of `lmax` and `mmax` cannot
+be uniquely inferred from the array size unless one assumes `lmax == mmax`.
+
+This class provides an explicit and robust interface to spherical harmonic data,
+allowing `mmax ≤ lmax` and supporting polarized (3-Stokes) and intensity-only
+(1-Stokes) cases. Internally, the coefficients are stored in a NumPy array
+of shape ``(nstokes, ncoeff)`` — this shape is always enforced, even for scalar
+(intensity-only) data.
+
+It supports:
+- Shape validation against `lmax` and `mmax`
+- Safe algebraic operations (addition, scaling, convolution)
+- Resizing via zero-padding or truncation
+- I/O through Healpy-compatible FITS files
+
+ 
 Example usage:
 
 .. testcode::

--- a/litebird_sim/spherical_harmonics.py
+++ b/litebird_sim/spherical_harmonics.py
@@ -1,8 +1,9 @@
 # -*- encoding: utf-8 -*-
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
+import healpy as hp
 
 
 @dataclass
@@ -18,6 +19,7 @@ class SphericalHarmonics:
     This small data class keeps the array and the values `l_max` and `m_max` together.
     The shape of `values` is *always* ``(nstokes, ncoeff)``, even if ``nstokes == 1``.
 
+    It also provides algebraic operations and I/O utilities compatible with Healpy.
 
     Attributes
     ----------
@@ -28,13 +30,46 @@ class SphericalHarmonics:
     mmax : int, optional
         The maximum order m_max of the expansion. If None, it is set equal to `lmax`.
     nstokes : int
-        The number of Stokes parameters (1 for intensity-only, 3 for polarization).
+        The number of Stokes parameters (1 for intensity-only, 3 for TEB).
+
+    Methods
+    -------
+    - num_of_alm_from_lmax(lmax, mmax=None)
+        Returns the number of a_ℓm coefficients for given `lmax` and `mmax`.
+    - lmax_from_num_of_alm(nalm, mmax=None)
+        Infers `lmax` from the number of coefficients and `mmax`.
+    - alm_array_size(lmax, mmax=None, nstokes=3)
+        Computes the expected shape of the coefficient array.
+    - alm_l_array(lmax, mmax=None)
+        Returns an array mapping coefficient indices to their ℓ values.
 
     Raises
     ------
     ValueError
         If `nstokes` is not 1 or 3.
         If the shape of `values` does not match the expected shape for given `lmax` and `mmax`.
+
+    Arithmetic
+    ----------
+    The following operations are supported:
+    - `+`, `-` between two SphericalHarmonics (same `lmax`, `mmax`, `nstokes`)
+    - `*` with scalar or Stokes-vector (array of shape `(nstokes,)`)
+    - `.convolve(f_ell)` applies a filter f_ell(ℓ) or f_ell^i(ℓ) per Stokes
+
+    I/O
+    ---
+    - `.write_fits(filename, overwrite=True)`
+        Saves the coefficients in a Healpy-compatible `.fits` file using `hp.write_alm`.
+    - `.read_fits(filename)`
+        Loads from a `.fits` file written by Healpy. Automatically supports 1 or 3 Stokes.
+
+    Example
+    -------
+    >>> from litebird_sim import SphericalHarmonics
+    >>> import numpy as np
+    >>> alm = np.ones((3, 55))  # (nstokes=3, nalm=55)
+    >>> sh = SphericalHarmonics(alm, lmax=9)
+    >>> sh_convolved = sh.convolve(np.arange(10))
     """
 
     values: np.ndarray
@@ -134,6 +169,32 @@ class SphericalHarmonics:
         return mmax * (2 * lmax + 1 - mmax) // 2 + lmax + 1
 
     @staticmethod
+    def lmax_from_num_of_alm(nalm: int, mmax: Optional[int] = None) -> int:
+        """
+        Returns the lmax corresponding to a given array size.
+
+        Parameters
+        ----------
+        nalm : int
+            Number of alm coefficients.
+        mmax : int, optional
+            Maximum m. If None, assumes full alm with mmax = lmax.
+
+        Returns
+        -------
+        int
+            The corresponding lmax, or -1 if `nalm` is not consistent.
+        """
+        if mmax is not None and mmax >= 0:
+            x = (2 * nalm + mmax**2 - mmax - 2) / (2 * mmax + 2)
+        else:
+            x = (-3 + np.sqrt(1 + 8 * nalm)) / 2
+
+        if not np.isclose(x, np.round(x)):
+            return -1
+        return int(round(x))
+
+    @staticmethod
     def alm_array_size(
         lmax: int, mmax: Optional[int] = None, nstokes: int = 3
     ) -> tuple[int, int]:
@@ -155,6 +216,40 @@ class SphericalHarmonics:
             The expected shape `(nstokes, ncoeff)`, where `ncoeff` is the number of a_ℓm coefficients.
         """
         return nstokes, SphericalHarmonics.num_of_alm_from_lmax(lmax, mmax)
+
+    @staticmethod
+    def alm_l_array(lmax: int, mmax: Optional[int] = None) -> np.ndarray:
+        """
+        Return the ℓ values corresponding to each a_{ℓm} coefficient in Healpy's flattened alm format.
+
+        This function reproduces the ℓ-indexing of Healpy's `alm` array layout, assuming the coefficients
+        are stored in the usual `(ℓ, m)` ordering with ℓ ≥ m.
+
+        Parameters
+        ----------
+        lmax : int
+            Maximum multipole ℓ included in the harmonic expansion.
+        mmax : int, optional
+            Maximum azimuthal number m. If None, defaults to `lmax`.
+
+        Returns
+        -------
+        np.ndarray
+            A 1D array of length equal to the number of alm coefficients, where each element
+            contains the corresponding ℓ value (degree) of that coefficient.
+
+        Examples
+        --------
+        >>> SphericalHarmonics.alm_l_array(3)
+        array([0, 1, 2, 3, 1, 2, 3, 2, 3, 3])
+        """
+        if mmax is None:
+            mmax = lmax
+
+        l_arr = []
+        for m in range(mmax + 1):
+            l_arr.extend(range(m, lmax + 1))
+        return np.array(l_arr, dtype=int)
 
     def resize_alm(
         self,
@@ -221,3 +316,213 @@ class SphericalHarmonics:
                 lmax=lmax_out,
                 mmax=mmax_out,
             )
+
+    # ============================================================
+    # Algebraic Operations
+    # ============================================================
+
+    def __add__(self, other):
+        if not isinstance(other, SphericalHarmonics):
+            raise TypeError("Can only add another SphericalHarmonics object")
+
+        if (
+            self.lmax != other.lmax
+            or self.mmax != other.mmax
+            or self.nstokes != other.nstokes
+        ):
+            raise ValueError(
+                "SphericalHarmonics objects must have matching lmax, mmax, and nstokes"
+            )
+
+        return SphericalHarmonics(
+            values=self.values + other.values, lmax=self.lmax, mmax=self.mmax
+        )
+
+    def __iadd__(self, other):
+        if not isinstance(other, SphericalHarmonics):
+            raise TypeError("Can only add another SphericalHarmonics object")
+
+        if (
+            self.lmax != other.lmax
+            or self.mmax != other.mmax
+            or self.nstokes != other.nstokes
+        ):
+            raise ValueError(
+                "SphericalHarmonics objects must have matching lmax, mmax, and nstokes"
+            )
+
+        self.values += other.values
+        return self
+
+    def __mul__(self, other: Union[float, np.ndarray]):
+        """
+        Supports:
+        - scalar multiplication: SH * A
+        - stokes-vector multiplication: SH * [A_T, A_E, A_B]
+        """
+        if isinstance(other, (float, int, complex)):
+            new_values = self.values * other
+        elif isinstance(other, np.ndarray):
+            if other.shape != (self.nstokes,):
+                raise ValueError(
+                    f"Stokes multiplier must have shape ({self.nstokes},), got {other.shape}"
+                )
+            new_values = self.values * other[:, None]
+        else:
+            raise TypeError("Can only multiply by scalar or Stokes vector")
+
+        return SphericalHarmonics(values=new_values, lmax=self.lmax, mmax=self.mmax)
+
+    def __rmul__(self, other: Union[float, np.ndarray]):
+        return self.__mul__(other)
+
+    def convolve(
+        self, f_ell: Union[np.ndarray, list[np.ndarray]]
+    ) -> "SphericalHarmonics":
+        """
+        Apply a beam or filter to the SH coefficients.
+
+        Parameters
+        ----------
+        f_ell : np.ndarray or list[np.ndarray]
+            The ℓ-dependent filter(s). Must be of shape (lmax+1,) or (nstokes, lmax+1)
+
+        Returns
+        -------
+        SphericalHarmonics
+            A new SphericalHarmonics object with filtered coefficients.
+        """
+        l_arr = self.alm_l_array(self.lmax, self.mmax)
+
+        if isinstance(f_ell, np.ndarray):
+            if f_ell.ndim == 1:
+                kernel = np.broadcast_to(f_ell[l_arr], self.values.shape)
+            elif f_ell.ndim == 2 and f_ell.shape[0] == self.nstokes:
+                kernel = np.stack([f[l_arr] for f in f_ell])
+            else:
+                raise ValueError(f"Invalid shape for f_ell: {f_ell.shape}")
+        elif isinstance(f_ell, list):
+            if len(f_ell) != self.nstokes:
+                raise ValueError(f"Expected {self.nstokes} filters, got {len(f_ell)}")
+            kernel = np.stack([np.asarray(f)[l_arr] for f in f_ell])
+        else:
+            raise TypeError("f_ell must be a numpy array or a list of numpy arrays")
+
+        return SphericalHarmonics(
+            values=self.values * kernel, lmax=self.lmax, mmax=self.mmax
+        )
+
+    def copy(self):
+        """Returns a deep copy of this SphericalHarmonics object."""
+        return SphericalHarmonics(
+            values=self.values.copy(), lmax=self.lmax, mmax=self.mmax
+        )
+
+    def __sub__(self, other):
+        if not isinstance(other, SphericalHarmonics):
+            raise TypeError("Subtraction requires another SphericalHarmonics object")
+        if (
+            self.lmax != other.lmax
+            or self.mmax != other.mmax
+            or self.nstokes != other.nstokes
+        ):
+            raise ValueError(
+                "SphericalHarmonics objects must have matching lmax, mmax, and nstokes"
+            )
+        return SphericalHarmonics(
+            values=self.values - other.values, lmax=self.lmax, mmax=self.mmax
+        )
+
+    def __isub__(self, other):
+        if not isinstance(other, SphericalHarmonics):
+            raise TypeError("Subtraction requires another SphericalHarmonics object")
+        if (
+            self.lmax != other.lmax
+            or self.mmax != other.mmax
+            or self.nstokes != other.nstokes
+        ):
+            raise ValueError(
+                "SphericalHarmonics objects must have matching lmax, mmax, and nstokes"
+            )
+        self.values -= other.values
+        return self
+
+    def __eq__(self, other):
+        if not isinstance(other, SphericalHarmonics):
+            return False
+        return (
+            self.lmax == other.lmax
+            and self.mmax == other.mmax
+            and self.nstokes == other.nstokes
+            and np.array_equal(self.values, other.values)
+        )
+
+    def allclose(self, other, rtol=1e-5, atol=1e-8):
+        """Compares SH values with tolerance."""
+        if not isinstance(other, SphericalHarmonics):
+            return False
+        return (
+            self.lmax == other.lmax
+            and self.mmax == other.mmax
+            and self.nstokes == other.nstokes
+            and np.allclose(self.values, other.values, rtol=rtol, atol=atol)
+        )
+
+    def write_fits(self, filename: str, overwrite: bool = True):
+        """
+        Save the SphericalHarmonics object to a Healpy-compatible .fits file.
+
+        Parameters
+        ----------
+        filename : str
+            The path to the output .fits file.
+        overwrite : bool
+            Whether to overwrite an existing file.
+        """
+        hp.write_alm(
+            filename,
+            self.values if self.nstokes == 3 else self.values[0],
+            lmax=self.lmax,
+            mmax=self.mmax,
+            overwrite=overwrite,
+            mmax_in=self.mmax,
+        )
+
+    @staticmethod
+    def read_fits(filename: str) -> "SphericalHarmonics":
+        """
+        Load a SphericalHarmonics object from a Healpy .fits file using only hp.read_alm.
+
+        This supports both 1-Stokes and 3-Stokes files written using hp.write_alm.
+
+        Parameters
+        ----------
+        filename : str
+            Path to the .fits file.
+
+        Returns
+        -------
+        SphericalHarmonics
+        """
+        try:
+            # Try to read all three Stokes components (T=1, E=2, B=3)
+            T, mmax = hp.read_alm(filename, hdu=1, return_mmax=True)
+
+            values = np.array(
+                [
+                    T,
+                    hp.read_alm(filename, hdu=2),
+                    hp.read_alm(filename, hdu=3),
+                ]
+            )
+            nalm = values.shape[1]
+        except Exception:
+            # Fallback to a single-Stokes file
+            alm, mmax = hp.read_alm(filename, return_mmax=True)
+            values = alm[np.newaxis, :]
+            nalm = values.shape[1]
+
+        # Compute lmax from nalm and mmax
+        lmax = SphericalHarmonics.lmax_from_num_of_alm(nalm, mmax)
+
+        return SphericalHarmonics(values=values, lmax=lmax, mmax=mmax)

--- a/test/test_spherical_harmonics.py
+++ b/test/test_spherical_harmonics.py
@@ -90,3 +90,75 @@ def test_spherical_harmonics():
 
     with pytest.raises(ValueError):
         _ = SphericalHarmonics(values, lmax=500)
+
+
+def test_arithmetic_operations():
+    lmax = 2
+    v1 = np.ones((3, SphericalHarmonics.num_of_alm_from_lmax(lmax)))
+    v2 = 2 * np.ones_like(v1)
+
+    sh1 = SphericalHarmonics(v1, lmax)
+    sh2 = SphericalHarmonics(v2, lmax)
+
+    sh_sum = sh1 + sh2
+    np.testing.assert_array_equal(sh_sum.values, 3 * np.ones_like(v1))
+
+    sh_scaled = sh1 * 2.0
+    np.testing.assert_array_equal(sh_scaled.values, 2.0 * np.ones_like(v1))
+
+    sh_scaled_vec = sh1 * np.array([1.0, 0.5, 0.0])
+    expected = v1 * np.array([[1.0], [0.5], [0.0]])
+    np.testing.assert_array_equal(sh_scaled_vec.values, expected)
+
+
+def test_convolution():
+    lmax = 3
+    nalm = SphericalHarmonics.num_of_alm_from_lmax(lmax)
+    values = np.ones((3, nalm))
+    sh = SphericalHarmonics(values, lmax)
+
+    # Scalar filter
+    f_ell = np.arange(lmax + 1)
+    sh_conv = sh.convolve(f_ell)
+
+    l_arr = SphericalHarmonics.alm_l_array(lmax)
+    kernel = f_ell[l_arr]
+
+    expected = values * kernel
+    np.testing.assert_array_equal(sh_conv.values, expected)
+
+    # Vector filter (per Stokes)
+    f_ell_vec = np.stack([f_ell, f_ell**2, np.ones_like(f_ell)])
+    sh_conv_vec = sh.convolve(f_ell_vec)
+
+    kernel_vec = np.stack([f[l_arr] for f in f_ell_vec])
+    expected_vec = values * kernel_vec
+
+    np.testing.assert_array_equal(sh_conv_vec.values, expected_vec)
+
+
+def test_healpy_io(tmp_path):
+    nside = 16
+
+    lmax = 10
+    mmax = 4
+
+    nstokes = 3
+
+    sh = SphericalHarmonics(
+        values=healpy.map2alm(
+            maps=np.random.rand(nstokes, healpy.nside2npix(nside)),
+            lmax=lmax,
+            mmax=mmax,
+            verbose=False,
+        ),
+        lmax=lmax,
+        mmax=mmax,
+    )
+    file = tmp_path / "test_alm.fits.gz"
+    sh.write_fits(str(file))
+
+    sh_loaded = SphericalHarmonics.read_fits(str(file))
+    np.testing.assert_allclose(sh_loaded.values, sh.values)
+    assert sh_loaded.lmax == sh.lmax
+    assert sh_loaded.mmax == sh.mmax


### PR DESCRIPTION
This PR adresses PR #446. 
In detail:
- Added support for arithmetic operations:
  - `+`, `-` between `SphericalHarmonics` objects
  - `*` with scalar or Stokes vector
- Implemented `.convolve()` method for scalar or per-Stokes ℓ-dependent filters
- Added `.allclose()` for tolerance-based comparison
- Improved Healpy-compatible I/O:
  - `.write_fits()` and `.read_fits()`
- Added utility methods:
  - `lmax_from_num_of_alm()` to infer `lmax` from alm size
  - `get_l_array()` to compute ℓ values in Healpy ordering
- Extended test coverage and updated docstring