### PR TITLE
Fix angle in hwp differential emission

### DIFF
--- a/litebird_sim/hwp_diff_emiss.py
+++ b/litebird_sim/hwp_diff_emiss.py
@@ -29,6 +29,7 @@ def add_2f_for_one_detector(tod_det, angle_det_rad, amplitude_k):
 def add_2f(
     tod,
     hwp_angle,
+    pol_angle_rad: float,
     amplitude_2f_k: float,
 ):
     """Add the HWP differential emission to some time-ordered data
@@ -48,7 +49,7 @@ def add_2f(
     for detector_idx in range(tod.shape[0]):
         add_2f_for_one_detector(
             tod_det=tod[detector_idx],
-            angle_det_rad=hwp_angle,
+            angle_det_rad=hwp_angle-pol_angle_rad[detector_idx],
             amplitude_k=amplitude_2f_k[detector_idx],
         )
 
@@ -90,6 +91,7 @@ def add_2f_to_observations(
 
         add_2f(
             tod=getattr(cur_obs, component),
-            hwp_angle=hwp_angle,
+            hwp_angle = hwp_angle,
+            pol_angle_rad=cur_obs.pol_angle_rad,
             amplitude_2f_k=amplitude_2f_k,
         )


### PR DESCRIPTION
This PR fixes the angle definition for the HWP differential emission to properly account for the detector polarization angle.

The existing modules shouldn't be affected by this change. 