### PR TITLE
Fix missing parallelizations in multiple places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Fix missing parallelizations in multiple places [#521](https://github.com/litebird/litebird_sim/pull/521)
+
 -   Refactor `input_sky.SkyGenerator` to reduce duplicated logic between channel/detector mode and frequency mode by using shared component-generation helpers for CMB, foregrounds, and dipole [#501](https://github.com/litebird/litebird_sim/pull/501)
 
 -   Simple pair differencing map-maker [#509](https://github.com/litebird/litebird_sim/pull/509)

--- a/litebird_sim/beam_convolution.py
+++ b/litebird_sim/beam_convolution.py
@@ -193,7 +193,7 @@ def add_convolved_sky_to_one_detector(
             pointings_det.astype(real_type, copy=False)
             if nside_centering is None
             else _get_centered_pointings(
-                pointings_det.astype(real_type, copy=False), nside_centering
+                pointings_det.astype(real_type, copy=False), nside_centering, nthreads
             )
         )[0]
     else:
@@ -211,7 +211,7 @@ def add_convolved_sky_to_one_detector(
             ptg=(
                 pointings_det
                 if nside_centering is None
-                else _get_centered_pointings(pointings_det, nside_centering)
+                else _get_centered_pointings(pointings_det, nside_centering, nthreads)
             ),
             alpha=hwp_angle,
             strict_typing=convolution_params.strict_typing,

--- a/litebird_sim/coordinates.py
+++ b/litebird_sim/coordinates.py
@@ -3,7 +3,7 @@ from enum import Enum
 import numpy as np
 from astropy.coordinates import BarycentricMeanEcliptic
 from astropy.coordinates import SkyCoord
-from numba import njit
+from numba import njit, prange
 
 """The coordinate system used by the framework"""
 DEFAULT_COORDINATE_SYSTEM = BarycentricMeanEcliptic()
@@ -193,7 +193,7 @@ def _rotate_coordinates_and_orientation_e2g_for_one_sample(
     return theta_gal_rad, phi_gal_rad, psi_gal_rad
 
 
-@njit
+@njit(parallel=True)
 def _rotate_coordinates_and_orientation_e2g_for_all(
     input_pointings_ecl_rad: np.ndarray,
     output_pointings_gal_rad: np.ndarray,
@@ -211,7 +211,7 @@ def _rotate_coordinates_and_orientation_e2g_for_all(
     """
 
     n_samples = input_pointings_ecl_rad.shape[0]
-    for i in range(n_samples):
+    for i in prange(n_samples):  # type: ignore[not-iterable]
         cur_theta_ecl_rad, cur_phi_ecl_rad, cur_psi_ecl_rad = input_pointings_ecl_rad[
             i, :
         ]

--- a/litebird_sim/grasp2alm.py
+++ b/litebird_sim/grasp2alm.py
@@ -13,15 +13,17 @@ from enum import IntEnum
 import typing
 import warnings
 from dataclasses import dataclass
+import os
 
 import ducc0.healpix
 import ducc0.sht
-from numba import njit
+from numba import njit, prange
 import numpy as np
 import numpy.typing as npt
 
 from .maps_and_harmonics import HealpixMap, SphericalHarmonics
 from .units import Units
+from .constants import NUM_THREADS_ENVVAR
 
 REASON_DESCRIPTION = {
     1: "Approximate solution found",
@@ -134,11 +136,11 @@ class BeamHealpixMap:
         return alm
 
 
-@njit
+@njit(parallel=True)
 def _to_polar_basis(theta_phi_values_rad: npt.NDArray, stokes: npt.NDArray) -> None:
     num_of_samples = theta_phi_values_rad.shape[0]
 
-    for i in range(num_of_samples):
+    for i in prange(num_of_samples):  # type: ignore[not-iterable]
         cur_theta = theta_phi_values_rad[i, 0]
         if cur_theta == 0:
             # No transformation is needed at the North Pole
@@ -317,6 +319,7 @@ class BeamStokesPolar:
         nside: int,
         nstokes: int = 3,
         unseen_pixel_value: float = 0.0,
+        nthreads: int | None = None,
     ) -> BeamHealpixMap:
         """Convert the :class:`.BeamPolar` to a :class:`.BeamMap`.
 
@@ -328,6 +331,8 @@ class BeamStokesPolar:
             nstokes (`int`): Number of Stokes parameters to project. The default is 3, which means
                 that three maps are produced: I, Q, and U.
             unseen_pixel_value (`float`): Value to fill outside the valid theta range.
+            nthreads (`int`): Number of threads to use in ducc's Healpix methods. If None,
+                the function reads from the `OMP_NUM_THREADS` environment variable.
 
         Returns:
             :class:`.BeamMap`: A new instance of ``BeamMap`` representing the beam map.
@@ -347,7 +352,9 @@ class BeamStokesPolar:
             beam_polar = self
 
         # Build the Stokes maps
-        pixel_indexes = base.ang2pix(self.theta_phi_values_rad)
+        if nthreads is None:
+            nthreads = int(os.environ.get(NUM_THREADS_ENVVAR, 0))
+        pixel_indexes = base.ang2pix(self.theta_phi_values_rad, nthreads=nthreads)
         beam_map = np.empty((nstokes, npix), dtype=float)
         hit_map = np.empty(npix, dtype=int)
         for stokes_idx in range(nstokes):

--- a/litebird_sim/hwp_diff_emiss.py
+++ b/litebird_sim/hwp_diff_emiss.py
@@ -1,7 +1,7 @@
 from numbers import Number
 
 import numpy as np
-from numba import njit
+from numba import njit, prange
 
 from .hwp import HWP
 from .observations import Observation
@@ -15,13 +15,15 @@ def compute_2f_for_one_sample(angle_rad, offset_rad, amplitude_k):
     return amplitude_k * np.cos(2 * (angle_rad - offset_rad))
 
 
-@njit
+@njit(parallel=True)
 def add_2f_for_one_detector(
     tod_det, angle_det_rad, offset_angle_rad: float, amplitude_k
 ):
-    for i, cur_angle in enumerate(angle_det_rad):  # type: ignore[not-iterable]
+    for i in prange(len(angle_det_rad)):  # type: ignore[not-iterable]
         tod_det[i] += compute_2f_for_one_sample(
-            angle_rad=cur_angle, offset_rad=offset_angle_rad, amplitude_k=amplitude_k
+            angle_rad=angle_det_rad[i],
+            offset_rad=offset_angle_rad,
+            amplitude_k=amplitude_k,
         )
 
 

--- a/litebird_sim/hwp_harmonics.py
+++ b/litebird_sim/hwp_harmonics.py
@@ -525,7 +525,7 @@ def fill_tod(
             pointings and tod (default: np.float32).
 
         apply_non_linearity (bool) : applies the coupling of the non-linearity
-              systematics with hwp_sys
+            systematics with hwp_sys
 
         add_2f_hwpss (bool) : adds the 2f hwpss signal to the TOD
 
@@ -535,9 +535,8 @@ def fill_tod(
 
         comm (SerialMpiCommunicator) : MPI communicator
 
-        nthreads : int, default=None
-            Number of threads to use in the convolution. If None, the function reads from the `OMP_NUM_THREADS`
-            environment variable.
+        nthreads (int) : number of threads to use in ducc's Healpix methods.
+            If None, the function reads from the `OMP_NUM_THREADS` environment variable.
 
     """
     if maps is None:
@@ -727,7 +726,9 @@ def fill_tod(
                 scheme = "NESTED" if maps_det.nest else "RING"
                 hpx = Healpix_Base(maps_det.nside, scheme)
 
-                pixel_ind_det = hpx.ang2pix(curr_pointings_det[:, 0:2])
+                pixel_ind_det = hpx.ang2pix(
+                    curr_pointings_det[:, 0:2], nthreads=nthreads
+                )
 
                 if maps_det.nstokes == 1:
                     input_T = pixmap[0, pixel_ind_det]

--- a/litebird_sim/mapmaking/binner.py
+++ b/litebird_sim/mapmaking/binner.py
@@ -10,12 +10,13 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
+import os
 
 import healpy as hp
 import numpy as np
 import numpy.typing as npt
 from ducc0.healpix import Healpix_Base
-from numba import njit
+from numba import njit, prange
 
 from litebird_sim import mpi
 from litebird_sim.coordinates import CoordinateSystem
@@ -27,6 +28,7 @@ from litebird_sim.pointings_in_obs import (
 )
 from litebird_sim.maps_and_harmonics import HealpixMap
 
+from .constants import NUM_THREADS_ENVVAR
 
 from .common import (
     COND_THRESHOLD,
@@ -68,7 +70,7 @@ class BinnerResult:
     time_split: str = "full"
 
 
-@njit
+@njit(parallel=True)
 def _solve_binning(nobs_matrix, atd):
     # Solve the map-making equation
     #
@@ -81,7 +83,7 @@ def _solve_binning(nobs_matrix, atd):
     # - `atd`: (N_p, 3)
     npix = atd.shape[0]
 
-    for ipix in range(npix):
+    for ipix in prange(npix):  # type: ignore[not-iterable]
         if np.linalg.cond(nobs_matrix[ipix]) < COND_THRESHOLD:
             atd[ipix] = np.linalg.solve(nobs_matrix[ipix], atd[ipix])
             nobs_matrix[ipix] = np.linalg.inv(nobs_matrix[ipix])
@@ -199,6 +201,7 @@ def _build_nobs_matrix(
     tm_list: list[npt.NDArray],
     output_coordinate_system: CoordinateSystem,
     components: list[str],
+    nthreads: int,
     pointings_dtype=np.float64,
 ) -> npt.NDArray:
     hpx = Healpix_Base(nside, "RING")
@@ -224,6 +227,7 @@ def _build_nobs_matrix(
             num_of_samples=cur_obs.n_samples,
             hwp_angle=hwp_angle,
             output_coordinate_system=output_coordinate_system,
+            nthreads=nthreads,
             pointings_dtype=pointings_dtype,
         )
 
@@ -280,6 +284,7 @@ def make_binned_map(
     detector_split: str = "full",
     time_split: str = "full",
     pointings_dtype=np.float64,
+    nthreads: int | None = None,
 ) -> BinnerResult:
     """Bin Map-maker
 
@@ -315,6 +320,9 @@ def make_binned_map(
         pointings_dtype(dtype): data type for pointings generated on the fly. If
             the pointing is passed or already precomputed this parameter is
             ineffective. Default is `np.float64`.
+        nthreads : int, default=None
+            Number of threads to use in ducc's Healpix methods. If None, the
+            function reads from the `OMP_NUM_THREADS` environment variable.
 
     Returns:
         An instance of the class :class:`.MapMakerResult`. If the observations are
@@ -333,6 +341,10 @@ def make_binned_map(
 
     time_mask_list = _build_mask_time_split(time_split, obs_list)
 
+    # Set number of threads
+    if nthreads is None:
+        nthreads = int(os.environ.get(NUM_THREADS_ENVVAR, 0))
+
     nobs_matrix = _build_nobs_matrix(
         nside=nside,
         obs_list=obs_list,
@@ -342,6 +354,7 @@ def make_binned_map(
         tm_list=time_mask_list,
         output_coordinate_system=output_coordinate_system,
         components=components,
+        nthreads=nthreads,
         pointings_dtype=pointings_dtype,
     )
 

--- a/litebird_sim/mapmaking/binner.py
+++ b/litebird_sim/mapmaking/binner.py
@@ -28,7 +28,7 @@ from litebird_sim.pointings_in_obs import (
 )
 from litebird_sim.maps_and_harmonics import HealpixMap
 
-from .constants import NUM_THREADS_ENVVAR
+from ..constants import NUM_THREADS_ENVVAR
 
 from .common import (
     COND_THRESHOLD,

--- a/litebird_sim/mapmaking/common.py
+++ b/litebird_sim/mapmaking/common.py
@@ -130,6 +130,7 @@ def _compute_pixel_indices(
     num_of_samples: int,
     hwp_angle: npt.NDArray | None,
     output_coordinate_system: CoordinateSystem,
+    nthreads: int,
     pointings_dtype=np.float64,
 ) -> tuple[npt.NDArray, npt.NDArray]:
     """Compute the index of each pixel and its attack angle
@@ -166,7 +167,7 @@ def _compute_pixel_indices(
             pol_angle_detectors=pol_angle_detectors[idet],
         )
 
-        pixidx_all[idet] = hpx.ang2pix(curr_pointings_det[:, :2])
+        pixidx_all[idet] = hpx.ang2pix(curr_pointings_det[:, :2], nthreads=nthreads)
 
     if output_coordinate_system == CoordinateSystem.Galactic:
         # Free curr_pointings_det if the output map is already in Galactic coordinates

--- a/litebird_sim/mapmaking/destriper.py
+++ b/litebird_sim/mapmaking/destriper.py
@@ -22,7 +22,7 @@ from litebird_sim.pointings_in_obs import (
     _normalize_observations_and_pointings,
 )
 
-from .constants import NUM_THREADS_ENVVAR
+from ..constants import NUM_THREADS_ENVVAR
 
 from .common import (
     _compute_pixel_indices,

--- a/litebird_sim/mapmaking/destriper.py
+++ b/litebird_sim/mapmaking/destriper.py
@@ -461,7 +461,6 @@ def _store_pixel_idx_and_pol_angle_in_obs(
         # - If not, compute or retrieve the HWP angle from the observation, depending on availability
         hwp_angle = _get_hwp_angle(obs=cur_obs, hwp=hwp, pointing_dtype=pointings_dtype)
 
-
         # Set number of threads
         if nthreads is None:
             nthreads = int(os.environ.get(NUM_THREADS_ENVVAR, 0))

--- a/litebird_sim/mapmaking/destriper.py
+++ b/litebird_sim/mapmaking/destriper.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 from collections.abc import Callable
+import os
 
 import healpy as hp
 import numpy as np
@@ -20,6 +21,9 @@ from litebird_sim.pointings_in_obs import (
     _get_hwp_angle,
     _normalize_observations_and_pointings,
 )
+
+from .constants import NUM_THREADS_ENVVAR
+
 from .common import (
     _compute_pixel_indices,
     COND_THRESHOLD,
@@ -111,7 +115,7 @@ def _get_invnpp(
 ):
     npix = nobs_matrix_cholesky.shape[0]
 
-    for ipix in range(npix):
+    for ipix in prange(npix):  # type: ignore[not-iterable]
         if not valid_pixel[ipix]:
             result[ipix, :, :] = 0.0
             continue
@@ -446,6 +450,7 @@ def _store_pixel_idx_and_pol_angle_in_obs(
     ptg_list: list[npt.NDArray | Callable],
     hwp: HWP | None,
     output_coordinate_system: CoordinateSystem,
+    nthreads: int,
     pointings_dtype=np.float64,
 ):
     for cur_obs, cur_ptg in zip(obs_list, ptg_list):
@@ -467,6 +472,7 @@ def _store_pixel_idx_and_pol_angle_in_obs(
             num_of_samples=cur_obs.n_samples,
             hwp_angle=hwp_angle,
             output_coordinate_system=output_coordinate_system,
+            nthreads=nthreads,
             pointings_dtype=pointings_dtype,
         )
 
@@ -541,7 +547,7 @@ def _sum_map_contribution_from_one_sample(
     dest_array[2] += sample * np.sin(2 * pol_angle_rad) / weight
 
 
-@njit
+@njit(parallel=True)
 def _update_sum_map_with_tod(
     sky_map: npt.NDArray,
     hit_map: npt.NDArray,
@@ -572,7 +578,7 @@ def _update_sum_map_with_tod(
         baseline_idx = 0
         samples_in_this_baseline = 0
 
-        for sample_idx in range(tod.shape[1]):
+        for sample_idx in prange(tod.shape[1]):  # type: ignore[not-iterable]
             if not t_mask[sample_idx]:
                 (baseline_idx, samples_in_this_baseline) = _step_over_baseline(
                     baseline_idx, samples_in_this_baseline, baseline_lengths
@@ -593,7 +599,7 @@ def _update_sum_map_with_tod(
             )
 
 
-@njit
+@njit(parallel=True)
 def _update_sum_map_with_baseline(
     sky_map: npt.NDArray,
     hit_map: npt.NDArray,
@@ -623,7 +629,7 @@ def _update_sum_map_with_baseline(
         baseline_idx = 0
         samples_in_this_baseline = 0
 
-        for sample_idx in range(pixel_idx.shape[1]):
+        for sample_idx in prange(pixel_idx.shape[1]):  # type: ignore[not-iterable]
             if not t_mask[sample_idx]:
                 (baseline_idx, samples_in_this_baseline) = _step_over_baseline(
                     baseline_idx, samples_in_this_baseline, baseline_lengths
@@ -644,7 +650,7 @@ def _update_sum_map_with_baseline(
             )
 
 
-@njit
+@njit(parallel=True)
 def _sum_map_to_binned_map(
     sky_map: npt.NDArray,
     nobs_matrix_cholesky: npt.NDArray,
@@ -652,7 +658,7 @@ def _sum_map_to_binned_map(
 ) -> None:
     """Convert a “sum map” into a “binned map” using the N_obs matrix"""
 
-    for cur_pix in range(sky_map.shape[1]):
+    for cur_pix in prange(sky_map.shape[1]):  # type: ignore[not-iterable]
         if valid_pixels[cur_pix]:
             cur_i, cur_q, cur_u = solve_cholesky(
                 L=nobs_matrix_cholesky[cur_pix, :],
@@ -770,7 +776,7 @@ def estimate_sample_from_map(
     return cur_i + cur_q * np.cos(2 * cur_psi) + cur_u * np.sin(2 * cur_psi)
 
 
-@njit
+@njit(parallel=True)
 def _compute_tod_sums_for_one_component(
     weights: npt.NDArray,
     tod: npt.NDArray,
@@ -805,7 +811,7 @@ def _compute_tod_sums_for_one_component(
         baseline_idx = 0
         samples_in_this_baseline = 0
 
-        for sample_idx in range(len(det_pixel_idx)):
+        for sample_idx in prange(len(det_pixel_idx)):  # type: ignore[not-iterable]
             if not t_mask[sample_idx]:
                 (baseline_idx, samples_in_this_baseline) = _step_over_baseline(
                     baseline_idx, samples_in_this_baseline, baseline_length
@@ -826,7 +832,7 @@ def _compute_tod_sums_for_one_component(
             )
 
 
-@njit
+@njit(parallel=True)
 def _compute_baseline_sums_for_one_component(
     weights: npt.NDArray,
     pixel_idx: npt.NDArray,
@@ -861,7 +867,7 @@ def _compute_baseline_sums_for_one_component(
         baseline_idx = 0
         samples_in_this_baseline = 0
 
-        for sample_idx in range(len(det_pixel_idx)):
+        for sample_idx in prange(len(det_pixel_idx)):  # type: ignore[not-iterable]
             if not t_mask[sample_idx]:
                 (baseline_idx, samples_in_this_baseline) = _step_over_baseline(
                     baseline_idx, samples_in_this_baseline, baseline_length
@@ -1468,6 +1474,7 @@ def make_destriped_map(
     callback: Any = destriper_log_callback,
     callback_kwargs: dict[Any, Any] | None = None,
     pointings_dtype=np.float64,
+    nthreads: int | None = None,
 ) -> DestriperResult:
     """
     Applies the destriping algorithm to produce a map out from a TOD
@@ -1564,6 +1571,9 @@ def make_destriped_map(
     :param pointings_dtype(dtype): data type for pointings generated on
         the fly. If the pointing is passed or already precomputed this
         parameter is ineffective. Default is `np.float64`.
+    :param nthreads: number of threads to use in ducc's Healpix methods.
+        If None, the function reads from the `OMP_NUM_THREADS` environment
+        variable.
 
     :return: an instance of the :class:`.DestriperResult`
        containing the destriped map and other useful information
@@ -1581,6 +1591,10 @@ def make_destriped_map(
 
     hpx = Healpix_Base(nside=nside, scheme="RING")
 
+    # Set number of threads
+    if nthreads is None:
+        nthreads = int(os.environ.get(NUM_THREADS_ENVVAR, 0))
+
     # Convert pointings and ψ angles according to the coordinate system,
     # convert them into Healpix indices and save the result into
     # each Observation object (don't worry, we will delete them
@@ -1591,6 +1605,7 @@ def make_destriped_map(
         ptg_list=ptg_list,
         hwp=hwp,
         output_coordinate_system=params.output_coordinate_system,
+        nthreads=nthreads,
         pointings_dtype=pointings_dtype,
     )
 
@@ -1785,7 +1800,7 @@ def make_destriped_map(
     )
 
 
-@njit
+@njit(parallel=True)
 def _remove_baselines(
     tod: npt.NDArray, baselines: npt.NDArray, baseline_lengths: npt.NDArray
 ):
@@ -1793,7 +1808,7 @@ def _remove_baselines(
     for det_idx in range(num_of_detectors):
         baseline_idx = 0
         samples_in_this_baseline = 0
-        for sample_idx in range(num_of_samples):
+        for sample_idx in prange(num_of_samples):  # type: ignore[not-iterable]
             tod[det_idx, sample_idx] -= baselines[det_idx, baseline_idx]
             (baseline_idx, samples_in_this_baseline) = _step_over_baseline(
                 baseline_idx, samples_in_this_baseline, baseline_lengths

--- a/litebird_sim/mapmaking/destriper.py
+++ b/litebird_sim/mapmaking/destriper.py
@@ -450,7 +450,7 @@ def _store_pixel_idx_and_pol_angle_in_obs(
     ptg_list: list[npt.NDArray | Callable],
     hwp: HWP | None,
     output_coordinate_system: CoordinateSystem,
-    nthreads: int,
+    nthreads: int | None = None,
     pointings_dtype=np.float64,
 ):
     for cur_obs, cur_ptg in zip(obs_list, ptg_list):
@@ -460,6 +460,11 @@ def _store_pixel_idx_and_pol_angle_in_obs(
         # - If an external HWP object is provided, compute the angle from it
         # - If not, compute or retrieve the HWP angle from the observation, depending on availability
         hwp_angle = _get_hwp_angle(obs=cur_obs, hwp=hwp, pointing_dtype=pointings_dtype)
+
+
+        # Set number of threads
+        if nthreads is None:
+            nthreads = int(os.environ.get(NUM_THREADS_ENVVAR, 0))
 
         (
             cur_obs.destriper_pixel_idx,
@@ -547,7 +552,7 @@ def _sum_map_contribution_from_one_sample(
     dest_array[2] += sample * np.sin(2 * pol_angle_rad) / weight
 
 
-@njit(parallel=True)
+@njit
 def _update_sum_map_with_tod(
     sky_map: npt.NDArray,
     hit_map: npt.NDArray,
@@ -578,7 +583,7 @@ def _update_sum_map_with_tod(
         baseline_idx = 0
         samples_in_this_baseline = 0
 
-        for sample_idx in prange(tod.shape[1]):  # type: ignore[not-iterable]
+        for sample_idx in range(tod.shape[1]):
             if not t_mask[sample_idx]:
                 (baseline_idx, samples_in_this_baseline) = _step_over_baseline(
                     baseline_idx, samples_in_this_baseline, baseline_lengths
@@ -599,7 +604,7 @@ def _update_sum_map_with_tod(
             )
 
 
-@njit(parallel=True)
+@njit
 def _update_sum_map_with_baseline(
     sky_map: npt.NDArray,
     hit_map: npt.NDArray,
@@ -629,7 +634,7 @@ def _update_sum_map_with_baseline(
         baseline_idx = 0
         samples_in_this_baseline = 0
 
-        for sample_idx in prange(pixel_idx.shape[1]):  # type: ignore[not-iterable]
+        for sample_idx in range(pixel_idx.shape[1]):
             if not t_mask[sample_idx]:
                 (baseline_idx, samples_in_this_baseline) = _step_over_baseline(
                     baseline_idx, samples_in_this_baseline, baseline_lengths
@@ -776,7 +781,7 @@ def estimate_sample_from_map(
     return cur_i + cur_q * np.cos(2 * cur_psi) + cur_u * np.sin(2 * cur_psi)
 
 
-@njit(parallel=True)
+@njit
 def _compute_tod_sums_for_one_component(
     weights: npt.NDArray,
     tod: npt.NDArray,
@@ -811,7 +816,7 @@ def _compute_tod_sums_for_one_component(
         baseline_idx = 0
         samples_in_this_baseline = 0
 
-        for sample_idx in prange(len(det_pixel_idx)):  # type: ignore[not-iterable]
+        for sample_idx in range(len(det_pixel_idx)):
             if not t_mask[sample_idx]:
                 (baseline_idx, samples_in_this_baseline) = _step_over_baseline(
                     baseline_idx, samples_in_this_baseline, baseline_length
@@ -832,7 +837,7 @@ def _compute_tod_sums_for_one_component(
             )
 
 
-@njit(parallel=True)
+@njit
 def _compute_baseline_sums_for_one_component(
     weights: npt.NDArray,
     pixel_idx: npt.NDArray,
@@ -867,7 +872,7 @@ def _compute_baseline_sums_for_one_component(
         baseline_idx = 0
         samples_in_this_baseline = 0
 
-        for sample_idx in prange(len(det_pixel_idx)):  # type: ignore[not-iterable]
+        for sample_idx in range(len(det_pixel_idx)):
             if not t_mask[sample_idx]:
                 (baseline_idx, samples_in_this_baseline) = _step_over_baseline(
                     baseline_idx, samples_in_this_baseline, baseline_length
@@ -1800,7 +1805,7 @@ def make_destriped_map(
     )
 
 
-@njit(parallel=True)
+@njit
 def _remove_baselines(
     tod: npt.NDArray, baselines: npt.NDArray, baseline_lengths: npt.NDArray
 ):
@@ -1808,7 +1813,7 @@ def _remove_baselines(
     for det_idx in range(num_of_detectors):
         baseline_idx = 0
         samples_in_this_baseline = 0
-        for sample_idx in prange(num_of_samples):  # type: ignore[not-iterable]
+        for sample_idx in range(num_of_samples):
             tod[det_idx, sample_idx] -= baselines[det_idx, baseline_idx]
             (baseline_idx, samples_in_this_baseline) = _step_over_baseline(
                 baseline_idx, samples_in_this_baseline, baseline_lengths

--- a/litebird_sim/mapmaking/pair_differencing.py
+++ b/litebird_sim/mapmaking/pair_differencing.py
@@ -10,12 +10,13 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
+import os
 
 import healpy as hp
 import numpy as np
 import numpy.typing as npt
 from ducc0.healpix import Healpix_Base
-from numba import njit
+from numba import njit, prange
 
 from litebird_sim import mpi
 from litebird_sim.coordinates import CoordinateSystem
@@ -27,6 +28,7 @@ from litebird_sim.pointings_in_obs import (
 )
 from litebird_sim.maps_and_harmonics import HealpixMap
 
+from .constants import NUM_THREADS_ENVVAR
 
 from .common import (
     COND_THRESHOLD,
@@ -68,7 +70,7 @@ class PairDifferencingResult:
     time_split: str = "full"
 
 
-@njit
+@njit(parallel=True)
 def _solve_binning(nobs_matrix, atd):
     # Solve the map-making equation
     #
@@ -81,7 +83,7 @@ def _solve_binning(nobs_matrix, atd):
     # - `atd`: (N_p, N_c)
     npix = atd.shape[0]
 
-    for ipix in range(npix):
+    for ipix in prange(npix):  # type: ignore[not-iterable]
         if np.linalg.cond(nobs_matrix[ipix]) < COND_THRESHOLD:
             atd[ipix] = np.linalg.solve(nobs_matrix[ipix], atd[ipix])
             nobs_matrix[ipix] = np.linalg.inv(nobs_matrix[ipix])
@@ -168,6 +170,7 @@ def _build_nobs_matrix(
     tm_list: list[npt.NDArray],
     output_coordinate_system: CoordinateSystem,
     components: list[str],
+    nthreads: int,
     pointings_dtype=np.float64,
 ) -> tuple[npt.NDArray, npt.NDArray]:
     hpx = Healpix_Base(nside, "RING")
@@ -194,6 +197,7 @@ def _build_nobs_matrix(
             num_of_samples=cur_obs.n_samples,
             hwp_angle=hwp_angle,
             output_coordinate_system=output_coordinate_system,
+            nthreads=nthreads,
             pointings_dtype=pointings_dtype,
         )
 
@@ -366,6 +370,7 @@ def make_pair_differenced_map(
     detector_split: str = "full",
     time_split: str = "full",
     pointings_dtype=np.float64,
+    nthreads: int | None = None,
 ) -> PairDifferencingResult:
     """QU pair-differencing map-maker
 
@@ -405,6 +410,9 @@ def make_pair_differenced_map(
         pointings_dtype(dtype): data type for pointings generated on the fly. If
             the pointing is passed or already precomputed this parameter is
             ineffective. Default is `np.float64`.
+        nthreads : int, default=None
+            Number of threads to use in ducc's Healpix methods. If None,
+            the function reads from the `OMP_NUM_THREADS` environment variable.
 
     Returns:
         An instance of the class :class:`.PairDifferencingResult`. If the observations are
@@ -425,6 +433,10 @@ def make_pair_differenced_map(
 
     time_mask_list = _build_mask_time_split(time_split, obs_list)
 
+    # Set number of threads
+    if nthreads is None:
+        nthreads = int(os.environ.get(NUM_THREADS_ENVVAR, 0))
+
     nobs_matrix, rhs = _build_nobs_matrix(
         nside=nside,
         obs_list=obs_list,
@@ -434,6 +446,7 @@ def make_pair_differenced_map(
         tm_list=time_mask_list,
         output_coordinate_system=output_coordinate_system,
         components=components,
+        nthreads=nthreads,
         pointings_dtype=pointings_dtype,
     )
 

--- a/litebird_sim/mapmaking/pair_differencing.py
+++ b/litebird_sim/mapmaking/pair_differencing.py
@@ -28,7 +28,7 @@ from litebird_sim.pointings_in_obs import (
 )
 from litebird_sim.maps_and_harmonics import HealpixMap
 
-from .constants import NUM_THREADS_ENVVAR
+from ..constants import NUM_THREADS_ENVVAR
 
 from .common import (
     COND_THRESHOLD,

--- a/litebird_sim/pointings_in_obs.py
+++ b/litebird_sim/pointings_in_obs.py
@@ -273,6 +273,7 @@ def _get_pointings_array(
 def _get_centered_pointings(
     input_pointings: npt.NDArray,
     nside_centering: int,
+    nthreads: int,
 ) -> np.ndarray:
     """Returns a copy of the input pointings aligned to the center of the HEALPix
     pixel they belong to.
@@ -283,6 +284,8 @@ def _get_centered_pointings(
         Pointing information of the detector
     nside_centering : int
         HEALPix NSIDE parameter used to determine the pixel centers.
+    nthreads : int, default=0
+        Number of threads to use for ducc healpix operations.
 
     Returns
     -------
@@ -294,7 +297,9 @@ def _get_centered_pointings(
     output_pointings = np.empty_like(input_pointings)
 
     # Apply centering on the first two columns (θ, φ)
-    output_pointings[:, 0:2] = hpx.pix2ang(hpx.ang2pix(input_pointings[:, 0:2]))
+    output_pointings[:, 0:2] = hpx.pix2ang(
+        hpx.ang2pix(input_pointings[:, 0:2], nthreads=nthreads), nthreads=nthreads
+    )
 
     # Copy any additional columns (e.g., polarization angles) without change
     if input_pointings.shape[1] > 2:

--- a/litebird_sim/scan_map.py
+++ b/litebird_sim/scan_map.py
@@ -77,7 +77,7 @@ def compute_signal_generic_hwp_for_one_sample(Stokes, Vpol, Rhwp, Mhwp, Rtel):
     return Vpol @ Rhwp.T @ Mhwp @ Rhwp @ Rtel @ Stokes
 
 
-@njit
+@njit(parallel=True)
 def scan_map_generic_hwp_for_one_detector(
     tod_det,
     input_T,
@@ -95,7 +95,7 @@ def scan_map_generic_hwp_for_one_detector(
     rot_hwp = np.eye(4, dtype=np.float64)
     rot_tel = np.eye(4, dtype=np.float64)
 
-    for i in range(len(tod_det)):
+    for i in prange(len(tod_det)):  # type: ignore[not-iterable]
         vec_stokes(vec_S, input_T[i], input_Q[i], input_U[i])
         rot_matrix(rot_hwp, hwp_angle[i])
         rot_matrix(rot_tel, orientation_telescope[i])
@@ -277,7 +277,7 @@ def scan_map(
             scheme = "NESTED" if maps_det.nest else "RING"
             hpx = Healpix_Base(maps_det.nside, scheme)
 
-            pixel_ind_det = hpx.ang2pix(curr_pointings_det[:, 0:2])
+            pixel_ind_det = hpx.ang2pix(curr_pointings_det[:, 0:2], nthreads=nthreads)
 
             if maps_det.nstokes == 1:
                 input_T = pixmap[0, pixel_ind_det]
@@ -544,6 +544,7 @@ def scan_map_in_observations(
                 add_2f_hwpss=add_2f_hwpss,
                 mueller_phases=mueller_phases,
                 comm=comm,
+                nthreads=nthreads,
             )
         else:
             # Standard scanning case


### PR DESCRIPTION
In a meeting with Luca, we realized there were several places in lbs in which we could be using numba's parallel loops and setting nthreads to the OMP number of threads to ducc's Healpix methods such as ang2pix.

This has (huge) immediate effects in the time consumption of lbs. Below is an example that Luca tried by making sequential changes for the execution of the same script which scans a map both in pixel (HealpixMap) and alm (SphericalHarmonics) space.

I scanned all lbs modules and tried to identify other places where these two aspects were missing and could be implemented without problems (e.g. avoiding cases where we could have concurrent access to the same object in memory with numba in parallel).

If something's missing or wrong, please tell me.

---
1 core
48 MPI tasks 
**Scan time (alms space):**  75.74711465835571s
**Scan time (pixel space):**  8.960188627243042s

2 MPI tasks - 24 threads 
**Scan time (alms space):**  146.47266101837158
**Scan time (pixel space):**  181.59398579597473

The time took by the pixel space method is ~24 times the time took in the previous case, meaning that it seems to only be using MPI and not the threads to decrease the computational time.

First, we noticed that the rotation of the points between coordinate systems was not using numba parallelization capabilities.

After prange inclusion in coordinates.py's `_rotate_coordinates_and_orientation_e2g_for_all()`:
**Scan time (alms space):**  25.625108003616333
**Scan time (pixel space):**  65.35376977920532

It became much faster! Then, we also realized that ducc's ang2pix implementation accepted a `nthreads` argument. Inserting it in scan_map() when interpolating the maps, we got these times:

After nthreads in ang2pix
**Scan time (alms space):**  25.600160360336304
**Scan time (pixel space):**  36.78679370880127

The alm scanning does not change, because the interpolation in that case [was already being parallelized](https://github.com/litebird/litebird_sim/blob/e63682c924249ba3e7d391176baf34618d90650e/litebird_sim/scan_map.py#L298), but the interpolation in the pixel space was not.

---